### PR TITLE
[chore] solid value improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,11 +1,18 @@
 {
   "configurations": [
     {
-      "name": "Example",
+      "name": "solidart Example",
+      "type": "dart",
+      "request": "launch",
+      "program": "main.dart",
+      "cwd": "packages/solidart/example"
+    },
+    {
+      "name": "flutter_solidart Example",
       "type": "dart",
       "request": "launch",
       "program": "lib/main.dart",
-      "cwd": "packages/solidart/example"
+      "cwd": "packages/flutter_solidart/example"
     },
     {
       "name": "Flutter: Run all Tests",

--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.3
+
+- Now `Solid.value` takes a list of [signalIds] and a [BuildContext]. You don't need anymore to get the signal first and pass it to `Solid.value`.
+- Set the minimum Dart SDK version to `2.18`.
+
 ## 0.1.2+1
 
 - Update Readme

--- a/packages/flutter_solidart/example/lib/pages/signals_in_modals.dart
+++ b/packages/flutter_solidart/example/lib/pages/signals_in_modals.dart
@@ -29,16 +29,15 @@ class _SignalsInModalsState extends State<SignalsInModals> {
   }
 
   Future<void> showCounterDialog(BuildContext context) {
-    // retrieve the counter with the context provided by the caller
-    final counter = context.get<Signal<int>>('counter');
     return showDialog(
       context: context,
       builder: (dialogContext) {
         // using `Solid.value` we provide the existing signal(s) to the dialog
         return Solid.value(
-          signals: {
-            'counter': () => counter,
-          },
+          // the context passed must have access to the Solid signals
+          context: context,
+          // the signals ids that we want to provide to the modal
+          signalIds: const ['counter'],
           child: Builder(builder: (context) {
             final counter = context.observe<int>('counter');
             return Dialog(

--- a/packages/flutter_solidart/example/lib/pages/signals_in_modals.dart
+++ b/packages/flutter_solidart/example/lib/pages/signals_in_modals.dart
@@ -3,6 +3,11 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
+enum _SignalId {
+  counter,
+  doubleCounter,
+}
+
 class SignalsInModals extends StatefulWidget {
   const SignalsInModals({super.key});
 
@@ -28,33 +33,6 @@ class _SignalsInModalsState extends State<SignalsInModals> {
     super.dispose();
   }
 
-  Future<void> showCounterDialog(BuildContext context) {
-    return showDialog(
-      context: context,
-      builder: (dialogContext) {
-        // using `Solid.value` we provide the existing signal(s) to the dialog
-        return Solid.value(
-          // the context passed must have access to the Solid signals
-          context: context,
-          // the signals ids that we want to provide to the modal
-          signalIds: const ['counter'],
-          child: Builder(builder: (context) {
-            final counter = context.observe<int>('counter');
-            return Dialog(
-              child: SizedBox(
-                width: 200,
-                height: 100,
-                child: Center(
-                  child: Text("The counter is $counter"),
-                ),
-              ),
-            );
-          }),
-        );
-      },
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -63,17 +41,23 @@ class _SignalsInModalsState extends State<SignalsInModals> {
       ),
       body: Solid(
         signals: {
-          'counter': () => counter,
+          _SignalId.counter: () => counter,
+          _SignalId.doubleCounter: () =>
+              counter.select<int>((value) => value * 2),
         },
         child: Builder(
           builder: (context) {
-            final counter = context.observe<int>('counter');
-            return Center(
+            final counter = context.observe<int>(_SignalId.counter);
+            final doubleCounter = context.observe<int>(_SignalId.doubleCounter);
+
+            return Align(
+              alignment: Alignment.topCenter,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Text('counter: $counter'),
+                  Text('doubleCounter: $doubleCounter'),
                   const SizedBox(height: 16),
                   ElevatedButton(
                     onPressed: () => showCounterDialog(context),
@@ -85,6 +69,40 @@ class _SignalsInModalsState extends State<SignalsInModals> {
           },
         ),
       ),
+    );
+  }
+
+  Future<void> showCounterDialog(BuildContext context) {
+    return showDialog(
+      context: context,
+      builder: (dialogContext) {
+        // using `Solid.value` we provide the existing signal(s) to the dialog
+        return Solid.value(
+          // the context passed must have access to the Solid signals
+          context: context,
+          // the signals ids that we want to provide to the modal
+          signalIds: const [_SignalId.counter, _SignalId.doubleCounter],
+          child: Builder(
+            builder: (innerContext) {
+              final counter = innerContext.observe<int>(_SignalId.counter);
+              final doubleCounter =
+                  innerContext.observe<int>(_SignalId.doubleCounter);
+              return Dialog(
+                child: SizedBox(
+                  width: 200,
+                  height: 100,
+                  child: Center(
+                    child: ListTile(
+                      title: Text("The counter is $counter"),
+                      subtitle: Text('The doubleCounter is $doubleCounter'),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/packages/flutter_solidart/lib/widgets/solid.dart
+++ b/packages/flutter_solidart/lib/widgets/solid.dart
@@ -12,17 +12,20 @@ class Solid extends StatefulWidget {
     required this.child,
   }) : _autoDisposeSignals = true;
 
-  /// Takes a map of signals and a [child] which will have access to the signals
-  /// New signals should not be created in `Solid.value`.
-  /// Signals should always be created using the default constructor
+  /// Takes a list of [signalIds], a [context] that must have access to the
+  /// signals and a [child] which will have access to the signals
   ///
-  /// This is useful for passing signals to modals, because them live in
-  /// another tree.
-  const Solid.value({
+  /// This is useful for passing signals to modals, because are spawned in a
+  /// new tree.
+  Solid.value({
     super.key,
-    required this.signals,
+    required BuildContext context,
+    required List<Object> signalIds,
     required this.child,
-  }) : _autoDisposeSignals = false;
+  })  : _autoDisposeSignals = false,
+        signals = {
+          for (final id in signalIds) id: () => get(context, id),
+        };
 
   final Widget child;
 

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,10 +1,10 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 0.1.2+1
+version: 0.1.3
 repository: https://github.com/nank1ro/solidart
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.8.0
-  solidart: ^0.1.0
+  solidart: ^0.1.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Set the minimum Dart SDK version to `2.18`.
+
 ## 0.1.0+6
 
 - Update Readme

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,10 +1,10 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 0.1.0+6
+version: 0.1.1
 repository: https://github.com/nank1ro/solidart
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   meta: ^1.8.0


### PR DESCRIPTION
Improved `Solid.value`, now instead of getting a Map of signals, it just takes their ids and a `BuildContext`.
You no longer need to retrieve the signal and pass it to `Solid.value` because the operation is already performed automatically under the hood.
Just provide a `BuildContext` that has access to `Solid` and a list of signal ids that you want to provide to your modal and you're ready to go.