### PR TITLE
🐞[bugfix] resource builder without fetcher

### DIFF
--- a/examples/counter/pubspec.yaml
+++ b/examples/counter/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^0.3.0
+  flutter_solidart: ^0.3.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/examples/todos/pubspec.yaml
+++ b/examples/todos/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^0.3.0
+  flutter_solidart: ^0.3.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/examples/toggle_theme/pubspec.yaml
+++ b/examples/toggle_theme/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^0.3.0
+  flutter_solidart: ^0.3.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+- The `select` method of a signal now can take a custom `options` parameter to customize its behaviour.
+- Fixed an invalid assert in the `ResourceBuilder` widget that happens for resources without a fetcher.
+
 ## 0.3.0
 
 - Now Solid can deal also with `SolidProviders`. You no longer need an external dependency injector library.

--- a/packages/flutter_solidart/example/pubspec.yaml
+++ b/packages/flutter_solidart/example/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  flutter_solidart: ^0.3.0
+  flutter_solidart: ^0.3.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
@@ -135,7 +135,10 @@ class _ResourceBuilderState<ResultType>
   @override
   void initState() {
     super.initState();
-    widget.resource.fetch();
+    // start fetching if the [fetcher] is present
+    if (widget.resource.fetcher != null) {
+      widget.resource.fetch();
+    }
   }
 
   @override

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart
 
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.8.0
-  solidart: ^0.2.2
+  solidart: ^0.2.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3
+
+- The `select` method of a signal now can take a custom `options` parameter to customize its behaviour.
+- Fixed an invalid assert in the `ResourceBuilder` widget that happens for resources without a fetcher.
+
 ## 0.2.2
 
 - `createResource` now accepts a `stream` and can be used to wrap a Stream and correctly handle its state.

--- a/packages/solidart/lib/src/core/readable_signal.dart
+++ b/packages/solidart/lib/src/core/readable_signal.dart
@@ -50,11 +50,13 @@ class ReadableSignal<T> implements SignalBase<T> {
   /// The [select] function allows filtering unwanted rebuilds by reading only
   /// the properties that we care about.
   ReadableSignal<Selected> select<Selected>(
-    Selected Function(T value) selector,
-  ) {
+    Selected Function(T value) selector, {
+    SignalOptions<Selected>? options,
+  }) {
     final signalSelector = SignalSelector<T, Selected>(
       signal: this as Signal<T>,
       selector: selector,
+      options: options,
     );
     // ignore: unnecessary_cast
     return signalSelector as ReadableSignal<Selected>;

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   meta: ^1.8.0
 
 dev_dependencies:
+  collection: ^1.17.1
   lints: ^2.0.0
   mockito: ^5.3.2
   test: ^1.16.0

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 0.2.2
+version: 0.2.3
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart
 


### PR DESCRIPTION
- The `select` method of a signal now can take a custom `options` parameter to customize its behaviour.
- Fixed an invalid assert in the `ResourceBuilder` widget that happens for resources without a fetcher.
