### PR TITLE
🐞[bugfix] show signal type

### DIFF
--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+- **BUGFIX**: The `Show` widget now can work again with a `ReadSignal`.
+
 ## 0.4.1
 
 - **CHORE**: The `ResourceBuilder` now correctly handles a different `Resource` when the widget is updated.

--- a/packages/flutter_solidart/lib/src/widgets/show.dart
+++ b/packages/flutter_solidart/lib/src/widgets/show.dart
@@ -61,7 +61,7 @@ class Show<T extends bool> extends StatelessWidget {
   ///
   /// When the Signal's value is true, renders the [builder], otherwise the
   ///  [fallback] (if provided, or an empty view).
-  final Signal<T> when;
+  final SignalBase<T> when;
 
   /// The builder widget is rendered when the [when] signal value evalutes to
   /// `true`

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 0.4.1
+version: 0.4.2
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart
 


### PR DESCRIPTION
The `Show` widget didn't accepted anymore a `ReadSignal`. This bug was introduced by mistake