### PR TITLE
[feat] show signal fn

### DIFF
--- a/docs/flutter/show.mdx
+++ b/docs/flutter/show.mdx
@@ -39,4 +39,18 @@ Widget build(BuildContext context) {
 The `Show` widget conditionally renders its `builder` or the `fallback` widget based on the `when` evaluation.
 The `fallback` widget builder is optional, by default nothing is rendered.
 
-The `Show` widget takes a `Signal` of type `bool`, see [Derived Signals](/learning/derived-signals) to learn how to create a derived signal if your Signal is not of type `bool`.
+The `Show` widget takes a functions that returns a `bool`.
+You easily convert any type to `bool`, for example:
+
+```dart
+final count = createSignal(0);
+
+@override
+Widget build(BuildContext context) {
+  return Show(
+    when: () => count() > 5,
+    builder: (context) => const Text('Count is greater than 5'),
+    fallback: (context) => const Text('Count is lower than 6'),
+  );
+}
+```

--- a/docs/learning/resources.mdx
+++ b/docs/learning/resources.mdx
@@ -38,19 +38,19 @@ The [source] field is ignored for the [stream] and used only for a [fetcher].
 
 If you are using the `flutter_solidart` library, check [ResourceBuilder](/flutter/resource-builder) to learn how to react to the state of the resource in the UI.
 
-The resource has a value named `ResourceValue`, that provides many useful convenience methods to correctly handle the state of the resource.
+The resource has a value named `ResourceState`, that provides many useful convenience methods to correctly handle the state of the resource.
 
 The `on` method forces you to handle all the states of a Resource (_ready_, _error_ and _loading_).
 The are also other convenience methods to handle only specific states:
 - `on` forces you to handle all the states of a Resource
 - `maybeOn` lets you decide which states to handle and provide an `orElse` action for unhandled states
-- `map` equal to `on` but gives access to the `ResourceValue` data class
-- `maybeMap` equal to `maybeMap` but gives access to the `ResourceValue` data class
+- `map` equal to `on` but gives access to the `ResourceState` data class
+- `maybeMap` equal to `maybeMap` but gives access to the `ResourceState` data class
 - `isReady` indicates if the `Resource` is in the ready state
 - `isLoading` indicates if the `Resource` is in the loading state
 - `hasError` indicates if the `Resource` is in the error state
-- `asReady` upcast `ResourceValue` into a `ResourceReady`, or return null if the `ResourceValue` is in loading/error state
-- `asError` upcast `ResourceValue` into a `ResourceError`, or return null if the `ResourceValue` is in loading/ready state
+- `asReady` upcast `ResourceState` into a `ResourceReady`, or return null if the `ResourceState` is in loading/error state
+- `asError` upcast `ResourceState` into a `ResourceError`, or return null if the `ResourceState` is in loading/ready state
 - `value` attempts to synchronously get the value of `ResourceReady`
 - `error` attempts to synchronously get the error of `ResourceError`
 

--- a/examples/counter/lib/main.dart
+++ b/examples/counter/lib/main.dart
@@ -41,7 +41,7 @@ class _CounterPageState extends State<CounterPage> {
       ),
       body: Center(
         child: SignalBuilder(
-          signal: counter,
+          signal: () => counter() * 2,
           builder: (_, value, __) {
             return Text('$value');
           },

--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.0.0-dev2
+
+The `Show` widget now takes a functions that returns a `bool`.
+You easily convert any type to `bool`, for example:
+
+```dart
+final count = createSignal(0);
+
+@override
+Widget build(BuildContext context) {
+  return Show(
+    when: () => count() > 5,
+    builder: (context) => const Text('Count is greater than 5'),
+    fallback: (context) => const Text('Count is lower than 6'),
+  );
+}
+```
+
 ## 1.0.0-dev1
 
 This is a development preview of the 1.0.0 release of solidart.

--- a/packages/flutter_solidart/example/lib/pages/show.dart
+++ b/packages/flutter_solidart/example/lib/pages/show.dart
@@ -10,14 +10,7 @@ class ShowPage extends StatefulWidget {
 }
 
 class _ShowPageState extends State<ShowPage> {
-  late final Signal<bool> loggedIn;
-
-  @override
-  void initState() {
-    super.initState();
-
-    loggedIn = createSignal(false);
-  }
+  final loggedIn = createSignal(false);
 
   @override
   void dispose() {
@@ -32,15 +25,14 @@ class _ShowPageState extends State<ShowPage> {
         title: const Text('Show'),
         actions: [
           TextButton(
-              style: TextButton.styleFrom(foregroundColor: Colors.white),
-              onPressed: () {
-                loggedIn.value = !loggedIn.value;
-              },
-              child: Show(
-                when: loggedIn,
-                builder: (_) => const Text('LOGIN'),
-                fallback: (_) => const Text('LOGOUT'),
-              ))
+            style: TextButton.styleFrom(foregroundColor: Colors.white),
+            onPressed: loggedIn.toggle,
+            child: Show(
+              when: loggedIn,
+              builder: (_) => const Text('LOGIN'),
+              fallback: (_) => const Text('LOGOUT'),
+            ),
+          )
         ],
       ),
       body: Center(

--- a/packages/flutter_solidart/example/lib/pages/solid.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid.dart
@@ -45,10 +45,11 @@ class _Counter extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           SignalBuilder(
-              signal: counter,
-              builder: (_, value, __) {
-                return Text(value.toString());
-              }),
+            signal: counter,
+            builder: (_, value, __) {
+              return Text(value.toString());
+            },
+          ),
           const SizedBox(height: 16),
           ElevatedButton(
             onPressed: () {
@@ -89,10 +90,11 @@ class _SentenceState extends State<_Sentence> {
         ),
         const SizedBox(height: 16),
         SignalBuilder(
-            signal: sentence,
-            builder: (_, value, __) {
-              return Text(value);
-            }),
+          signal: sentence,
+          builder: (_, value, __) {
+            return Text(value);
+          },
+        ),
         const SizedBox(height: 16),
         ElevatedButton(
           onPressed: () {

--- a/packages/flutter_solidart/lib/src/widgets/signal_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/signal_builder.dart
@@ -44,7 +44,7 @@ class SignalBuilder<T> extends StatefulWidget {
   });
 
   /// {@template signalbuilder.signal}
-  /// The signal function whose value you depend on in order to build.
+  /// The signal whose value you depend on in order to build.
   ///
   /// This widget does not ensure that the signal's value is not
   /// null, therefore your [builder] may need to handle null values.

--- a/packages/flutter_solidart/lib/src/widgets/signal_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/signal_builder.dart
@@ -44,7 +44,7 @@ class SignalBuilder<T> extends StatefulWidget {
   });
 
   /// {@template signalbuilder.signal}
-  /// The signal whose value you depend on in order to build.
+  /// The signal function whose value you depend on in order to build.
   ///
   /// This widget does not ensure that the signal's value is not
   /// null, therefore your [builder] may need to handle null values.
@@ -80,7 +80,8 @@ class SignalBuilder<T> extends StatefulWidget {
 
 class _SignalBuilderState<T> extends State<SignalBuilder<T>> {
   late T value;
-  DisposeEffect? disposeFn;
+  late DisposeEffect disposeFn;
+  bool initialized = false;
 
   @override
   void initState() {
@@ -93,7 +94,7 @@ class _SignalBuilderState<T> extends State<SignalBuilder<T>> {
   void didUpdateWidget(SignalBuilder<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.signal != widget.signal) {
-      disposeFn?.call();
+      disposeFn();
       _initializeSignal();
     }
   }
@@ -101,21 +102,15 @@ class _SignalBuilderState<T> extends State<SignalBuilder<T>> {
 
   @override
   void dispose() {
-    disposeFn?.call();
+    disposeFn();
     super.dispose();
   }
 
   void _initializeSignal() {
-    value = widget.signal.value;
-    disposeFn = widget.signal.observe(
-      (_, __) => _valueChanged(),
-      fireImmediately: false,
-    );
-  }
-
-  void _valueChanged() {
-    setState(() {
-      value = widget.signal.value;
+    disposeFn = createEffect((dispose) {
+      value = widget.signal();
+      if (initialized) setState(() {});
+      initialized = true;
     });
   }
 
@@ -185,46 +180,39 @@ class DualSignalBuilder<T, U> extends StatefulWidget {
 class _DualSignalBuilderState<T, U> extends State<DualSignalBuilder<T, U>> {
   late T firstValue;
   late U secondValue;
-  DisposeEffect? disposeFn1;
-  DisposeEffect? disposeFn2;
+  late DisposeEffect disposeFn;
+  bool initialized = false;
 
   @override
   void initState() {
     super.initState();
-    firstValue = widget.firstSignal.value;
-    disposeFn1 = widget.firstSignal.observe((_, __) => _valueChanged());
-    secondValue = widget.secondSignal.value;
-    disposeFn2 = widget.secondSignal.observe((_, __) => _valueChanged());
+    _initializeSignals();
   }
 
   // coverage:ignore-start
   @override
   void didUpdateWidget(DualSignalBuilder<T, U> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.firstSignal != widget.firstSignal) {
-      disposeFn1?.call();
-      firstValue = widget.firstSignal.value;
-      disposeFn1 = widget.firstSignal.observe((_, __) => _valueChanged());
-    }
-    if (oldWidget.secondSignal != widget.secondSignal) {
-      disposeFn2?.call();
-      secondValue = widget.secondSignal.value;
-      disposeFn2 = widget.secondSignal.observe((_, __) => _valueChanged());
+    if (oldWidget.firstSignal != widget.firstSignal ||
+        oldWidget.secondSignal != widget.secondSignal) {
+      disposeFn();
+      _initializeSignals();
     }
   }
   // coverage:ignore-end
 
   @override
   void dispose() {
-    disposeFn1?.call();
-    disposeFn2?.call();
+    disposeFn();
     super.dispose();
   }
 
-  void _valueChanged() {
-    setState(() {
-      firstValue = widget.firstSignal.value;
-      secondValue = widget.secondSignal.value;
+  void _initializeSignals() {
+    disposeFn = createEffect((_) {
+      firstValue = widget.firstSignal();
+      secondValue = widget.secondSignal();
+      if (initialized) setState(() {});
+      initialized = true;
     });
   }
 
@@ -307,56 +295,41 @@ class _TripleSignalBuilderState<T, U, R>
   late U secondValue;
   late R thirdValue;
 
-  DisposeEffect? disposeFn1;
-  DisposeEffect? disposeFn2;
-  DisposeEffect? disposeFn3;
+  late DisposeEffect disposeFn;
+  bool initialized = false;
 
   @override
   void initState() {
     super.initState();
-    firstValue = widget.firstSignal.value;
-    disposeFn1 = widget.firstSignal.observe((_, __) => _valueChanged());
-    secondValue = widget.secondSignal.value;
-    disposeFn2 = widget.secondSignal.observe((_, __) => _valueChanged());
-    thirdValue = widget.thirdSignal.value;
-    disposeFn3 = widget.thirdSignal.observe((_, __) => _valueChanged());
+    _initializeSignals();
   }
 
   // coverage:ignore-start
   @override
   void didUpdateWidget(TripleSignalBuilder<T, U, R> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.firstSignal != widget.firstSignal) {
-      disposeFn1?.call();
-      firstValue = widget.firstSignal.value;
-      disposeFn1 = widget.firstSignal.observe((_, __) => _valueChanged());
-    }
-    if (oldWidget.secondSignal != widget.secondSignal) {
-      disposeFn2?.call();
-      secondValue = widget.secondSignal.value;
-      disposeFn2 = widget.secondSignal.observe((_, __) => _valueChanged());
-    }
-    if (oldWidget.thirdSignal != widget.thirdSignal) {
-      disposeFn3?.call();
-      thirdValue = widget.thirdSignal.value;
-      disposeFn3 = widget.thirdSignal.observe((_, __) => _valueChanged());
+    if (oldWidget.firstSignal != widget.firstSignal ||
+        oldWidget.secondSignal != widget.secondSignal ||
+        oldWidget.thirdSignal != widget.thirdSignal) {
+      disposeFn();
+      _initializeSignals();
     }
   }
   // coverage:ignore-end
 
   @override
   void dispose() {
-    disposeFn1?.call();
-    disposeFn2?.call();
-    disposeFn3?.call();
+    disposeFn();
     super.dispose();
   }
 
-  void _valueChanged() {
-    setState(() {
-      firstValue = widget.firstSignal.value;
-      secondValue = widget.secondSignal.value;
-      thirdValue = widget.thirdSignal.value;
+  void _initializeSignals() {
+    disposeFn = createEffect((_) {
+      firstValue = widget.firstSignal();
+      secondValue = widget.secondSignal();
+      thirdValue = widget.thirdSignal();
+      if (initialized) setState(() {});
+      initialized = true;
     });
   }
 

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 1.0.0-dev1
+version: 1.0.0-dev2
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:
@@ -8,7 +8,7 @@ topics:
   - signals
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ^3.0.0
   flutter: ">=1.17.0"
 
 dependencies:

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -37,7 +37,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: Show(
-            when: s,
+            when: s.call,
             builder: (context) => const Text('Builder'),
             fallback: (context) => const Text('Fallback'),
           ),

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -463,7 +463,7 @@ void main() {
       resource.dispose();
     });
 
-    test('check ResourceValue.on', () async {
+    test('check ResourceState.on', () async {
       var shouldThrow = false;
       Future<int> fetcher() {
         return Future.delayed(const Duration(milliseconds: 150), () {

--- a/packages/solidart_lint/CHANGELOG.md
+++ b/packages/solidart_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-dev2
+
+Rename ResourceValue into ResourceState
+
 ## 1.0.0-dev1
 
 Fix lints for the development preview of solidart 1.0.0

--- a/packages/solidart_lint/lib/src/assists/wrap_with_resource_builder.dart
+++ b/packages/solidart_lint/lib/src/assists/wrap_with_resource_builder.dart
@@ -31,8 +31,8 @@ class WrapWithResourceBuilder extends DartAssist {
             node.offset,
             'ResourceBuilder(\n'
             'resource: null,\n'
-            'builder: (context, resourceValue) {\n'
-            'return resourceValue.on(\n'
+            'builder: (context, resourceState) {\n'
+            'return resourceState.on(\n'
             'ready: (value, isRefreshing) {\n'
             'return ');
         builder.addSimpleInsertion(

--- a/packages/solidart_lint/pubspec.yaml
+++ b/packages/solidart_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart_lint
 description: solidart_lint is a developer tool for users of solidart, designed to help stop common issues and simplify repetitive tasks
-version: 1.0.0-dev1
+version: 1.0.0-dev2
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart
 topics:


### PR DESCRIPTION
The `Show` widget now takes a functions that returns a `bool`.
You easily convert any type to `bool`, for example:

```dart
final count = createSignal(0);

@override
Widget build(BuildContext context) {
  return Show(
    when: () => count() > 5,
    builder: (context) => const Text('Count is greater than 5'),
    fallback: (context) => const Text('Count is lower than 6'),
  );
}
```
