### PR TITLE
[feat] add Wrapped class

### DIFF
--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -207,11 +207,17 @@ class Computed<T> extends Signal<T> implements Derivation {
     final hadCaughtException = context.hasCaughtException(this);
 
     final newValue = _computeValue(track: true);
-
     final changedException =
         hadCaughtException != context.hasCaughtException(this);
-    final changed =
-        wasSuspended || changedException || !areEqual(oldValue, newValue);
+    bool didAsyncTransition() =>
+        (oldValue == null) && (newValue != null) ||
+        (oldValue != null) && (newValue == null);
+    bool bothInReadyState() => (oldValue != null) && (newValue != null);
+
+    final changed = wasSuspended ||
+        changedException ||
+        didAsyncTransition() ||
+        (bothInReadyState() && !areEqual(oldValue!.unwrap, newValue!.unwrap));
 
     if (changed) {
       _previousValue = oldValue;

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -73,10 +73,10 @@ class Computed<T> extends Signal<T> implements Derivation {
         super(selector(), options: options);
 
   // Tracks the internal value
-  T? _value;
+  Wrapped<T>? _value;
 
   // Tracks the internal previous value
-  T? _previousValue;
+  Wrapped<T>? _previousValue;
 
   @override
   // ignore: overridden_fields
@@ -141,12 +141,12 @@ class Computed<T> extends Signal<T> implements Derivation {
     if (context.hasCaughtException(this)) {
       throw errorValue!;
     }
-    return _value as T;
+    return _value!.unwrap;
   }
 
   /// The previous value, if any.
   @override
-  T? get previousValue {
+  Wrapped<T>? get previousValue {
     final prevVal = _value;
     // get the actual value to cause observation
     final _ = value;
@@ -175,20 +175,20 @@ class Computed<T> extends Signal<T> implements Derivation {
 
       notifyChange();
 
-      _previousValue = newValue;
+      _previousValue = Wrapped(newValue);
     });
   }
 
-  T? _computeValue({required bool track}) {
+  Wrapped<T>? _computeValue({required bool track}) {
     _isComputing = true;
     context.pushComputation();
 
-    T? computedValue;
+    Wrapped<T>? computedValue;
     if (track) {
       computedValue = context.trackDerivation(this, selector);
     } else {
       try {
-        computedValue = selector();
+        computedValue = Wrapped(selector());
         errorValue = null;
       } on Object catch (e, s) {
         errorValue = SolidartCaughtException(e, stackTrace: s);

--- a/packages/solidart/lib/src/core/reactive_context.dart
+++ b/packages/solidart/lib/src/core/reactive_context.dart
@@ -120,12 +120,12 @@ class ReactiveContext {
     _bindDependencies(currentDerivation);
   }
 
-  T? trackDerivation<T>(Derivation d, T Function() fn) {
+  Wrapped<T>? trackDerivation<T>(Derivation d, T Function() fn) {
     final prevDerivation = startTracking(d);
-    T? result;
+    Wrapped<T>? result;
 
     try {
-      result = fn();
+      result = Wrapped(fn());
       d.errorValue = null;
     } on Object catch (e, s) {
       d.errorValue = SolidartCaughtException(e, stackTrace: s);

--- a/packages/solidart/lib/src/core/read_signal.dart
+++ b/packages/solidart/lib/src/core/read_signal.dart
@@ -48,7 +48,7 @@ class ReadSignal<T> extends Atom implements SignalBase<T> {
 
   // coverage:ignore-start
   @override
-  T? get previousValue {
+  Wrapped<T>? get previousValue {
     // no-op
     return null;
   }

--- a/packages/solidart/lib/src/core/resource.dart
+++ b/packages/solidart/lib/src/core/resource.dart
@@ -4,6 +4,7 @@ import 'package:meta/meta.dart';
 import 'package:solidart/src/core/signal.dart';
 import 'package:solidart/src/core/signal_base.dart';
 import 'package:solidart/src/core/signal_options.dart';
+import 'package:solidart/src/utils.dart';
 
 /// {@template resource-options}
 /// {@macro signaloptions}
@@ -510,9 +511,9 @@ extension ResourceExtensions<T> on ResourceState<T> {
   ///
   /// On error, this will rethrow the error.
   /// If loading, will return `null`.
-  T? get value {
+  Wrapped<T>? get value {
     return map(
-      ready: (r) => r.value,
+      ready: (r) => Wrapped(r.value),
       // ignore: only_throw_errors
       error: (r) => throw r.error,
       loading: (_) => null,
@@ -523,7 +524,7 @@ extension ResourceExtensions<T> on ResourceState<T> {
   ///
   /// On error, this will rethrow the error.
   /// If loading, will return `null`.
-  T? call() => value;
+  Wrapped<T>? call() => value;
 
   /// Attempts to synchronously get the error of [ResourceError].
   ///

--- a/packages/solidart/lib/src/core/signal.dart
+++ b/packages/solidart/lib/src/core/signal.dart
@@ -131,7 +131,7 @@ class Signal<T> extends ReadSignal<T> {
   // Tracks the internal value
   T _value;
   // Tracks the internal previous value
-  T? _previousValue;
+  Wrapped<T>? _previousValue;
 
   @override
   T get value {
@@ -155,7 +155,7 @@ class Signal<T> extends ReadSignal<T> {
     }
 
     // store the previous value
-    _previousValue = _value;
+    _previousValue = Wrapped(_value);
 
     // notify with the new value
     _value = newValue;
@@ -163,9 +163,9 @@ class Signal<T> extends ReadSignal<T> {
     _notifyListeners();
   }
 
-  /// Indicates if the [oldValue] and the [newValue] are equal
+  /// Indicates if the [oldValue] and the [newValue] are equal.
   @internal
-  bool areEqual(T? oldValue, T? newValue) {
+  bool areEqual(T oldValue, T newValue) {
     // skip if the value are equals
     if (options.equals && oldValue == newValue) {
       return true;
@@ -175,12 +175,13 @@ class Signal<T> extends ReadSignal<T> {
     if (!options.equals && options.comparator != null) {
       return options.comparator!(oldValue, newValue);
     }
+
     return false;
   }
 
   /// The previous value, if any.
   @override
-  T? get previousValue {
+  Wrapped<T>? get previousValue {
     reportObserved();
     return _previousValue;
   }

--- a/packages/solidart/lib/src/core/signal_base.dart
+++ b/packages/solidart/lib/src/core/signal_base.dart
@@ -17,7 +17,7 @@ abstract class SignalBase<T> {
   /// The previous signal value
   ///
   /// Defaults to null when no previous value is present.
-  T? get previousValue;
+  Wrapped<T>? get previousValue;
 
   /// Options used to customize the behaviour of a signal
   SignalOptions<T> get options;

--- a/packages/solidart/lib/src/core/signal_options.dart
+++ b/packages/solidart/lib/src/core/signal_options.dart
@@ -38,7 +38,7 @@ class SignalOptions<T> {
   /// Preventing signal updates if the [comparator] returns true.
   ///
   /// Taken into account only if [equals] is false.
-  final ValueComparator<T?>? comparator;
+  final ValueComparator<T>? comparator;
 
   /// The name of the signal, useful for logging purposes.
   final String? name;

--- a/packages/solidart/lib/src/utils.dart
+++ b/packages/solidart/lib/src/utils.dart
@@ -10,7 +10,7 @@ typedef VoidCallback = void Function();
 typedef ErrorCallback = void Function(Object error);
 
 /// The callback fired by the observer
-typedef ObserveCallback<T> = void Function(T? previousValue, T value);
+typedef ObserveCallback<T> = void Function(Wrapped<T>? previousValue, T value);
 
 /// {@template solidartexception}
 /// An Exception class to capture Solidart specific exceptions

--- a/packages/solidart/lib/src/utils.dart
+++ b/packages/solidart/lib/src/utils.dart
@@ -60,4 +60,79 @@ class SolidartCaughtException extends SolidartException {
 /// Creates a delayer scheduler with the given [duration].
 Timer Function(void Function()) createDelayedScheduler(Duration duration) =>
     (fn) => Timer(duration, fn);
+
 /// coverage:ignore-end
+
+/// {@template data}
+/// A wrapper class that makes it possible to distinguish
+/// between `null` as valid instance of [T] and `null` as not present.
+/// Especially useful if [T] is nullable.
+/// {@endtemplate}
+@immutable
+class Wrapped<T> {
+  /// {@macro data}
+  const Wrapped(T value) : _value = value;
+
+  final T _value;
+
+  /// Unwraps the data held by the instance. Usage examples:
+  ///
+  /// - If [T] is nullable:
+  ///
+  /// ```dart
+  ///   try {
+  ///     final wrappedData = userResourceState.wrappedData;
+  ///     if (wrappedData == null) {
+  ///       // in loading state
+  ///
+  ///       // do something signalizing we are in loading state
+  ///     } else {
+  ///       // in data state
+  ///
+  ///       final data = wrappedData.unwrap();
+  ///       if (data == null) {
+  ///         // do something with data-is-null case
+  ///       } else {
+  ///         // do something with data
+  ///       }
+  ///     }
+  ///   } catch (e) {
+  ///     // in error state
+  /// 
+  ///     // handle error
+  ///   }
+  /// ```
+  ///
+  /// - If [T] is not nullable:
+  ///
+  ///   ```dart
+  ///   try {
+  ///     final wrappedData = userResourceState.wrappedData;
+  ///     if (wrappedData == null) {
+  ///       // in loading state
+  /// 
+  ///       // do something signalizing we are in loading state
+  ///     } else {
+  ///       // in data state
+  ///
+  ///       final data = wrappedData.unwrap(); // no need to make distinction
+  ///       // do something with data
+  ///     }
+  ///   } catch (e) {
+  ///     // in error state
+  /// 
+  ///     // handle error
+  ///   }
+  ///   ```
+  T get unwrap => _value;
+
+  @override
+  bool operator ==(Object other) =>
+    identical(this, other) ||
+    other is Wrapped &&
+    runtimeType == other.runtimeType &&
+    _value == other._value;
+
+  @override
+  int get hashCode => _value.hashCode;
+}

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -108,7 +108,7 @@ void main() {
         'returns false', () async {
       final signal = createSignal(
         null,
-        options: const SignalOptions<_A>(),
+        options: const SignalOptions<_A?>(),
       );
       final cb = MockCallbackFunction();
       final unobserve = signal.observe((_, __) => cb());
@@ -166,14 +166,14 @@ void main() {
 
       expect(
         s.previousValue,
-        0,
+        const Wrapped(0),
         reason: 'The signal should have 0 has previousValue',
       );
 
       s.update((value) => value * 5);
       expect(
         s.previousValue,
-        1,
+        const Wrapped(1),
         reason: 'The signal should have 1 has previousValue',
       );
     });
@@ -337,15 +337,15 @@ void main() {
 
       signal.set(1);
       await pumpEventQueue();
-      expect(derived.previousValue, 0);
+      expect(derived.previousValue, const Wrapped(0));
 
       signal.set(2);
       await pumpEventQueue();
-      expect(derived.previousValue, 2);
+      expect(derived.previousValue, const Wrapped(2));
 
       signal.set(1);
       await pumpEventQueue();
-      expect(derived.previousValue, 4);
+      expect(derived.previousValue, const Wrapped(4));
     });
 
     test('derived signal disposes', () async {
@@ -406,12 +406,12 @@ void main() {
       streamController.add(1);
       await pumpEventQueue();
       expect(resource.state, isA<ResourceReady<int>>());
-      expect(resource.state.value, 1);
+      expect(resource.state.value, const Wrapped(1));
 
       streamController.add(10);
       await pumpEventQueue();
       expect(resource.state, isA<ResourceReady<int>>());
-      expect(resource.state(), 10);
+      expect(resource.state(), const Wrapped(10));
 
       streamController.addError(UnimplementedError());
       await pumpEventQueue();
@@ -446,12 +446,12 @@ void main() {
       await resource.resolve();
       await pumpEventQueue();
       expect(resource.state, isA<ResourceReady<User>>());
-      expect(resource.state.value, const User(id: 0));
+      expect(resource.state.value, const Wrapped(User(id: 0)));
 
       userId.set(1);
       await pumpEventQueue();
       expect(resource.state, isA<ResourceReady<User>>());
-      expect(resource.state(), const User(id: 1));
+      expect(resource.state(), const Wrapped(User(id: 1)));
 
       userId.set(2);
       await pumpEventQueue();


### PR DESCRIPTION
The PR adds a  `Wrapped<T>` class. This class is used:
-  to distinguish between loading and ready states. With `Wrapped<T>?`, `null` indicates loading, while `Wrapped<T>` indicates ready.
- to distinguish between a previous value whose value is `null` and a non-existent previous value (this is the case when the value was set only once).

To unwrap a wrapped value, use the getter: `wrappedValue.unwrap`.

The proposed approach should be preferred over the current `T?` approach, as `T?` is not as type-safe (if `T` is nullable):
- with `T?`, `null` could be interpreted as either a valid instance of `T` or as not present.

I also managed to simplify the comparator type to `ValueComparator<T>?` (thanks to an added getter, async state transitions always result in updates, e.g. loading -> ready). This was done because of the introduction of `Wrapped`.

What are your thoughts on this feature? Can you think of a better name than `Wrapped`? Should i change the class member names ending in `value` to `wrappedValue` or similar, in case they are `Wrapped` instances?