### PR TITLE
[feat] support refreshing in error state

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,28 +114,42 @@ If you're using `ResourceBuilder` you can react to the state of the resource:
 ```dart
 ResourceBuilder(
   resource: user,
-  builder: (_, resource) {
-    return resource.on(
-      // the call was successful
-      ready: (data, refreshing) {
+  builder: (_, userState) {
+    return userState.on(
+      ready: (data) {
         return Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             ListTile(
               title: Text(data),
-              subtitle: Text('refreshing: $refreshing'),
+              subtitle:
+                  Text('refreshing: ${userState.isRefreshing}'),
             ),
-            ElevatedButton(
-              // you can refetch if you want to update the data
-              onPressed: user.refetch,
-              child: const Text('Refresh'),
-            ),
+            if (userState.isRefreshing)
+              const CircularProgressIndicator(),
+            if (!userState.isRefreshing)
+              ElevatedButton(
+                onPressed: user.refetch,
+                child: const Text('Refresh'),
+              ),
           ],
         );
       },
-      // the call failed.
-      error: (e, _) => Text(e.toString()),
-      // the call is loading.
+      error: (e, _) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(e.toString()),
+            if (userState.isRefreshing)
+              const CircularProgressIndicator(),
+            if (!userState.isRefreshing)
+              ElevatedButton(
+                onPressed: user.refetch,
+                child: const Text('Refresh'),
+              ),
+          ],
+        );
+      },
       loading: () {
         return const RepaintBoundary(
           child: CircularProgressIndicator(),

--- a/docs/flutter/resource-builder.mdx
+++ b/docs/flutter/resource-builder.mdx
@@ -44,7 +44,10 @@ class _ResourcePageState extends State<ResourcePage> {
 
   // fetcher
   Future<String> fetchUser() async {
-    print('Fetch user: ${userId.value}');
+    print('fetchUser function called (with 2s initial delay)');
+    // simulating a delay to mimic a slow HTTP request
+    await Future.delayed(const Duration(seconds: 2));
+    print('Now fetching user: ${userId.value}');
     final response = await http.get(
       Uri.parse('https://swapi.dev/api/people/${userId.value}/'),
     );

--- a/docs/flutter/resource-builder.mdx
+++ b/docs/flutter/resource-builder.mdx
@@ -86,14 +86,29 @@ class _ResourcePageState extends State<ResourcePage> {
                           title: Text(data),
                           subtitle: Text('refreshing: $refreshing'),
                         ),
-                        ElevatedButton(
-                          onPressed: user.refetch,
-                          child: const Text('Refresh'),
-                        ),
+                        if (refreshing) const CircularProgressIndicator(),
+                        if (!refreshing)
+                          ElevatedButton(
+                            onPressed: user.refetch,
+                            child: const Text('Refresh'),
+                          ),
                       ],
                     );
                   },
-                  error: (e, _) => Text(e.toString()),
+                  error: (e, _, refreshing) {
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(e.toString()),
+                        if (refreshing) const CircularProgressIndicator(),
+                        if (!refreshing)
+                          ElevatedButton(
+                            onPressed: user.refetch,
+                            child: const Text('Refresh'),
+                          ),
+                      ],
+                    );
+                  },
                   loading: () {
                     return const RepaintBoundary(
                       child: CircularProgressIndicator(),

--- a/docs/flutter/resource-builder.mdx
+++ b/docs/flutter/resource-builder.mdx
@@ -76,18 +76,20 @@ class _ResourcePageState extends State<ResourcePage> {
             const SizedBox(height: 16),
             ResourceBuilder(
               resource: user,
-              builder: (_, userValue) {
-                return userValue.on(
-                  ready: (data, refreshing) {
+              builder: (_, userState) {
+                return userState.on(
+                  ready: (data) {
                     return Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         ListTile(
                           title: Text(data),
-                          subtitle: Text('refreshing: $refreshing'),
+                          subtitle:
+                              Text('refreshing: ${userState.isRefreshing}'),
                         ),
-                        if (refreshing) const CircularProgressIndicator(),
-                        if (!refreshing)
+                        if (userState.isRefreshing)
+                          const CircularProgressIndicator(),
+                        if (!userState.isRefreshing)
                           ElevatedButton(
                             onPressed: user.refetch,
                             child: const Text('Refresh'),
@@ -95,13 +97,14 @@ class _ResourcePageState extends State<ResourcePage> {
                       ],
                     );
                   },
-                  error: (e, _, refreshing) {
+                  error: (e, _) {
                     return Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         Text(e.toString()),
-                        if (refreshing) const CircularProgressIndicator(),
-                        if (!refreshing)
+                        if (userState.isRefreshing)
+                          const CircularProgressIndicator(),
+                        if (!userState.isRefreshing)
                           ElevatedButton(
                             onPressed: user.refetch,
                             child: const Text('Refresh'),

--- a/packages/flutter_solidart/README.md
+++ b/packages/flutter_solidart/README.md
@@ -112,28 +112,42 @@ Using `ResourceBuilder` you can react to the state of the resource:
 ```dart
 ResourceBuilder(
   resource: user,
-  builder: (_, resource) {
-    return resource.on(
-      // the call was successful
-      ready: (data, refreshing) {
+  builder: (_, userState) {
+    return userState.on(
+      ready: (data) {
         return Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             ListTile(
               title: Text(data),
-              subtitle: Text('refreshing: $refreshing'),
+              subtitle:
+                  Text('refreshing: ${userState.isRefreshing}'),
             ),
-            ElevatedButton(
-              // you can refetch if you want to update the data
-              onPressed: user.refetch,
-              child: const Text('Refresh'),
-            ),
+            if (userState.isRefreshing)
+              const CircularProgressIndicator(),
+            if (!userState.isRefreshing)
+              ElevatedButton(
+                onPressed: user.refetch,
+                child: const Text('Refresh'),
+              ),
           ],
         );
       },
-      // the call failed.
-      error: (e, _) => Text(e.toString()),
-      // the call is loading.
+      error: (e, _) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(e.toString()),
+            if (userState.isRefreshing)
+              const CircularProgressIndicator(),
+            if (!userState.isRefreshing)
+              ElevatedButton(
+                onPressed: user.refetch,
+                child: const Text('Refresh'),
+              ),
+          ],
+        );
+      },
       loading: () {
         return const RepaintBoundary(
           child: CircularProgressIndicator(),

--- a/packages/flutter_solidart/example/lib/pages/resource.dart
+++ b/packages/flutter_solidart/example/lib/pages/resource.dart
@@ -66,18 +66,20 @@ class _ResourcePageState extends State<ResourcePage> {
             const SizedBox(height: 16),
             ResourceBuilder(
               resource: user,
-              builder: (_, userValue) {
-                return userValue.on(
-                  ready: (data, refreshing) {
+              builder: (_, userState) {
+                return userState.on(
+                  ready: (data) {
                     return Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         ListTile(
                           title: Text(data),
-                          subtitle: Text('refreshing: $refreshing'),
+                          subtitle:
+                              Text('refreshing: ${userState.isRefreshing}'),
                         ),
-                        if (refreshing) const CircularProgressIndicator(),
-                        if (!refreshing)
+                        if (userState.isRefreshing)
+                          const CircularProgressIndicator(),
+                        if (!userState.isRefreshing)
                           ElevatedButton(
                             onPressed: user.refetch,
                             child: const Text('Refresh'),
@@ -85,13 +87,14 @@ class _ResourcePageState extends State<ResourcePage> {
                       ],
                     );
                   },
-                  error: (e, _, refreshing) {
+                  error: (e, _) {
                     return Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         Text(e.toString()),
-                        if (refreshing) const CircularProgressIndicator(),
-                        if (!refreshing)
+                        if (userState.isRefreshing)
+                          const CircularProgressIndicator(),
+                        if (!userState.isRefreshing)
                           ElevatedButton(
                             onPressed: user.refetch,
                             child: const Text('Refresh'),

--- a/packages/flutter_solidart/example/lib/pages/resource.dart
+++ b/packages/flutter_solidart/example/lib/pages/resource.dart
@@ -16,7 +16,13 @@ class _ResourcePageState extends State<ResourcePage> {
   @override
   void initState() {
     super.initState();
-    user = createResource(fetcher: fetchUser, source: userId);
+    user = createResource(
+      fetcher: () async {
+        await Future.delayed(const Duration(seconds: 2));
+        return await fetchUser();
+      },
+      source: userId,
+    );
   }
 
   @override
@@ -70,14 +76,29 @@ class _ResourcePageState extends State<ResourcePage> {
                           title: Text(data),
                           subtitle: Text('refreshing: $refreshing'),
                         ),
-                        ElevatedButton(
-                          onPressed: user.refetch,
-                          child: const Text('Refresh'),
-                        ),
+                        if (refreshing) const CircularProgressIndicator(),
+                        if (!refreshing)
+                          ElevatedButton(
+                            onPressed: user.refetch,
+                            child: const Text('Refresh'),
+                          ),
                       ],
                     );
                   },
-                  error: (e, _) => Text(e.toString()),
+                  error: (e, _, refreshing) {
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(e.toString()),
+                        if (refreshing) const CircularProgressIndicator(),
+                        if (!refreshing)
+                          ElevatedButton(
+                            onPressed: user.refetch,
+                            child: const Text('Refresh'),
+                          ),
+                      ],
+                    );
+                  },
                   loading: () {
                     return const RepaintBoundary(
                       child: CircularProgressIndicator(),

--- a/packages/flutter_solidart/example/lib/pages/resource.dart
+++ b/packages/flutter_solidart/example/lib/pages/resource.dart
@@ -27,11 +27,8 @@ class _ResourcePageState extends State<ResourcePage> {
   }
 
   Future<String> fetchUser() async {
-    // ignore: avoid_print
-    print('fetchUser function called (with 2s initial delay)');
     // simulating a delay to mimic a slow HTTP request
     await Future.delayed(const Duration(seconds: 2));
-    print('Now fetching user: ${userId.value}');
     final response = await http.get(
       Uri.parse('https://swapi.dev/api/people/${userId.value}/'),
     );

--- a/packages/flutter_solidart/example/lib/pages/resource.dart
+++ b/packages/flutter_solidart/example/lib/pages/resource.dart
@@ -16,13 +16,7 @@ class _ResourcePageState extends State<ResourcePage> {
   @override
   void initState() {
     super.initState();
-    user = createResource(
-      fetcher: () async {
-        await Future.delayed(const Duration(seconds: 2));
-        return await fetchUser();
-      },
-      source: userId,
-    );
+    user = createResource(fetcher: fetchUser, source: userId);
   }
 
   @override
@@ -34,7 +28,10 @@ class _ResourcePageState extends State<ResourcePage> {
 
   Future<String> fetchUser() async {
     // ignore: avoid_print
-    print('Fetch user: ${userId.value}');
+    print('fetchUser function called (with 2s initial delay)');
+    // simulating a delay to mimic a slow HTTP request
+    await Future.delayed(const Duration(seconds: 2));
+    print('Now fetching user: ${userId.value}');
     final response = await http.get(
       Uri.parse('https://swapi.dev/api/people/${userId.value}/'),
     );

--- a/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
@@ -50,7 +50,6 @@ typedef ResourceWidgetBuilder<T> = Widget Function(
 ///
 ///   // fetcher
 ///   Future<String> fetchUser() async {
-///     print('Fetch user: ${userId.value}');
 ///     final response = await http.get(
 ///       Uri.parse('https://swapi.dev/api/people/${userId.value}/'),
 ///     );

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -70,13 +70,17 @@ void main() {
         home: Scaffold(
           body: ResourceBuilder(
             resource: r,
-            builder: (context, resource) {
-              return resource.on(
-                ready: (data, refreshing) {
-                  return Text('Data: $data (refreshing: $refreshing)');
+            builder: (context, resourceState) {
+              return resourceState.on(
+                ready: (data) {
+                  return Text(
+                    'Data: $data (refreshing: ${resourceState.isRefreshing})',
+                  );
                 },
-                error: (err, _, refreshing) {
-                  return Text('Error (refreshing: $refreshing)');
+                error: (err, _) {
+                  return Text(
+                    'Error (refreshing: ${resourceState.isRefreshing})',
+                  );
                 },
                 loading: () {
                   return const Text('Loading');
@@ -101,7 +105,7 @@ void main() {
     unawaited(r.refetch());
     await tester.pumpAndSettle(const Duration(milliseconds: 40));
     expect(dataFinder(0, refreshing: true), findsOneWidget);
-    expect(errorFinder(), findsNothing);
+    expect(errorFinder(refreshing: true), findsNothing);
     expect(loadingFinder, findsNothing);
 
     await tester.pumpAndSettle();
@@ -123,13 +127,17 @@ void main() {
         home: Scaffold(
           body: ResourceBuilder(
             resource: r,
-            builder: (context, resource) {
-              return resource.on(
-                ready: (data, refreshing) {
-                  return Text('Data: $data (refreshing: $refreshing)');
+            builder: (context, resourceState) {
+              return resourceState.on(
+                ready: (data) {
+                  return Text(
+                    'Data: $data (refreshing: ${resourceState.isRefreshing})',
+                  );
                 },
-                error: (err, _, refreshing) {
-                  return Text('Error (refreshing: $refreshing)');
+                error: (err, _) {
+                  return Text(
+                    'Error (refreshing: ${resourceState.isRefreshing})',
+                  );
                 },
                 loading: () {
                   return const Text('Loading');
@@ -161,7 +169,10 @@ void main() {
       (tester) async {
     final s = createSignal(0);
     Future<int> fetcher() {
-      return Future.microtask(() => throw Exception());
+      return Future.delayed(
+        const Duration(milliseconds: 150),
+        () => throw Exception(),
+      );
     }
 
     final r = createResource(fetcher: fetcher, source: s);
@@ -170,13 +181,17 @@ void main() {
         home: Scaffold(
           body: ResourceBuilder(
             resource: r,
-            builder: (context, resource) {
-              return resource.on(
-                ready: (data, refreshing) {
-                  return Text('Data: $data (refreshing: $refreshing)');
+            builder: (context, resourceState) {
+              return resourceState.on(
+                ready: (data) {
+                  return Text(
+                    'Data: $data (refreshing: ${resourceState.isRefreshing})',
+                  );
                 },
-                error: (err, _, refreshing) {
-                  return Text('Error (refreshing: $refreshing)');
+                error: (err, _) {
+                  return Text(
+                    'Error (refreshing: ${resourceState.isRefreshing})',
+                  );
                 },
                 loading: () {
                   return const Text('Loading');
@@ -193,18 +208,18 @@ void main() {
         find.text('Error (refreshing: $refreshing)');
     final loadingFinder = find.text('Loading');
 
-    await tester.pumpAndSettle();
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
     expect(dataFinder(0), findsNothing);
     expect(errorFinder(), findsOneWidget);
-    expect(loadingFinder, findsNothing);   
+    expect(loadingFinder, findsNothing);
 
     unawaited(r.refetch());
     await tester.pumpAndSettle(const Duration(milliseconds: 40));
-    expect(dataFinder(0), findsNothing);
-    expect(errorFinder(), findsOneWidget); // TODO: should be errorFinder(refreshing: true)
+    expect(dataFinder(0, refreshing: true), findsNothing);
+    expect(errorFinder(refreshing: true), findsOneWidget);
     expect(loadingFinder, findsNothing);
 
-    await tester.pumpAndSettle();
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
     expect(dataFinder(0), findsNothing);
     expect(errorFinder(), findsOneWidget);
     expect(loadingFinder, findsNothing);

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -73,10 +73,10 @@ void main() {
             builder: (context, resource) {
               return resource.on(
                 ready: (data, refreshing) {
-                  return Text('Data: $data refreshing: $refreshing');
+                  return Text('Data: $data (refreshing: $refreshing)');
                 },
-                error: (err, _) {
-                  return const Text('Error');
+                error: (err, _, refreshing) {
+                  return Text('Error (refreshing: $refreshing)');
                 },
                 loading: () {
                   return const Text('Loading');
@@ -88,24 +88,25 @@ void main() {
       ),
     );
     Finder dataFinder(int value, {bool refreshing = false}) =>
-        find.text('Data: $value refreshing: $refreshing');
-    final errorFinder = find.text('Error');
+        find.text('Data: $value (refreshing: $refreshing)');
+    Finder errorFinder({bool refreshing = false}) =>
+        find.text('Error (refreshing: $refreshing)');
     final loadingFinder = find.text('Loading');
 
     await tester.pumpAndSettle();
     expect(dataFinder(0), findsOneWidget);
-    expect(errorFinder, findsNothing);
+    expect(errorFinder(), findsNothing);
     expect(loadingFinder, findsNothing);
 
     unawaited(r.refetch());
     await tester.pumpAndSettle(const Duration(milliseconds: 40));
     expect(dataFinder(0, refreshing: true), findsOneWidget);
-    expect(errorFinder, findsNothing);
+    expect(errorFinder(), findsNothing);
     expect(loadingFinder, findsNothing);
 
     await tester.pumpAndSettle();
     expect(dataFinder(0), findsOneWidget);
-    expect(errorFinder, findsNothing);
+    expect(errorFinder(), findsNothing);
     expect(loadingFinder, findsNothing);
   });
 
@@ -125,10 +126,10 @@ void main() {
             builder: (context, resource) {
               return resource.on(
                 ready: (data, refreshing) {
-                  return Text('Data: $data refreshing: $refreshing');
+                  return Text('Data: $data (refreshing: $refreshing)');
                 },
-                error: (err, _) {
-                  return const Text('Error');
+                error: (err, _, refreshing) {
+                  return Text('Error (refreshing: $refreshing)');
                 },
                 loading: () {
                   return const Text('Loading');
@@ -140,18 +141,19 @@ void main() {
       ),
     );
     Finder dataFinder(int value, {bool refreshing = false}) =>
-        find.text('Data: $value refreshing: $refreshing');
-    final errorFinder = find.text('Error');
+        find.text('Data: $value (refreshing: $refreshing)');
+    Finder errorFinder({bool refreshing = false}) =>
+        find.text('Error (refreshing: $refreshing)');
     final loadingFinder = find.text('Loading');
 
     await tester.pumpAndSettle();
     expect(dataFinder(0), findsNothing);
-    expect(errorFinder, findsNothing);
+    expect(errorFinder(), findsNothing);
     expect(loadingFinder, findsOneWidget);
 
     await tester.pumpAndSettle();
     expect(dataFinder(0), findsOneWidget);
-    expect(errorFinder, findsNothing);
+    expect(errorFinder(), findsNothing);
     expect(loadingFinder, findsNothing);
   });
 
@@ -171,10 +173,10 @@ void main() {
             builder: (context, resource) {
               return resource.on(
                 ready: (data, refreshing) {
-                  return Text('Data: $data refreshing: $refreshing');
+                  return Text('Data: $data (refreshing: $refreshing)');
                 },
-                error: (err, _) {
-                  return const Text('Error');
+                error: (err, _, refreshing) {
+                  return Text('Error (refreshing: $refreshing)');
                 },
                 loading: () {
                   return const Text('Loading');
@@ -186,13 +188,25 @@ void main() {
       ),
     );
     Finder dataFinder(int value, {bool refreshing = false}) =>
-        find.text('Data: $value refreshing: $refreshing');
-    final errorFinder = find.text('Error');
+        find.text('Data: $value (refreshing: $refreshing)');
+    Finder errorFinder({bool refreshing = false}) =>
+        find.text('Error (refreshing: $refreshing)');
     final loadingFinder = find.text('Loading');
 
     await tester.pumpAndSettle();
     expect(dataFinder(0), findsNothing);
-    expect(errorFinder, findsOneWidget);
+    expect(errorFinder(), findsOneWidget);
+    expect(loadingFinder, findsNothing);   
+
+    unawaited(r.refetch());
+    await tester.pumpAndSettle(const Duration(milliseconds: 40));
+    expect(dataFinder(0), findsNothing);
+    expect(errorFinder(), findsOneWidget); // TODO: should be errorFinder(refreshing: true)
+    expect(loadingFinder, findsNothing);
+
+    await tester.pumpAndSettle();
+    expect(dataFinder(0), findsNothing);
+    expect(errorFinder(), findsOneWidget);
     expect(loadingFinder, findsNothing);
   });
 

--- a/packages/solidart/lib/src/core/resource.dart
+++ b/packages/solidart/lib/src/core/resource.dart
@@ -65,10 +65,10 @@ Resource<T> createResource<T>({
 ///
 /// // The fetcher
 /// Future<String> fetchUser() async {
-///     final response = await http.get(
-///       Uri.parse('https://swapi.dev/api/people/${userId.value}/'),
-///     );
-///     return response.body;
+///   final response = await http.get(
+///     Uri.parse('https://swapi.dev/api/people/${userId.value}/'),
+///   );
+///   return response.body;
 /// }
 ///
 /// // The resource (source is optional)

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -470,7 +470,7 @@ void main() {
 
       resource.state.on(
         ready: (data, refreshing) {},
-        error: (error, stack) {},
+        error: (error, stack, refreshing) {},
         loading: () {},
       );
 
@@ -489,7 +489,8 @@ void main() {
       var dataCalledTimes = 0;
       var loadingCalledTimes = 0;
       var errorCalledTimes = 0;
-      var refreshingTrueTimes = 0;
+      var refreshingOnDataTimes = 0;
+      var refreshingOnErrorTimes = 0;
       final resource = createResource(fetcher: fetcher);
       resource.resolve().ignore();
 
@@ -498,13 +499,17 @@ void main() {
           resource.state.on(
             ready: (data, refreshing) {
               if (refreshing) {
-                refreshingTrueTimes++;
+                refreshingOnDataTimes++;
               } else {
                 dataCalledTimes++;
               }
             },
-            error: (error, stackTrace) {
-              errorCalledTimes++;
+            error: (error, stackTrace, refreshing) {
+              if (refreshing) {
+                refreshingOnErrorTimes++;
+              } else {
+                errorCalledTimes++;
+              }
             },
             loading: () {
               loadingCalledTimes++;
@@ -521,7 +526,7 @@ void main() {
 
       resource.refetch().ignore();
       await Future<void>.delayed(const Duration(milliseconds: 40));
-      expect(refreshingTrueTimes, 1);
+      expect(refreshingOnDataTimes, 1);
       await Future<void>.delayed(const Duration(milliseconds: 150));
       expect(dataCalledTimes, 2);
 
@@ -530,10 +535,21 @@ void main() {
       resource.refetch().ignore();
       await Future<void>.delayed(const Duration(milliseconds: 150));
       expect(errorCalledTimes, 1);
+      expect(refreshingOnErrorTimes, 0);
 
       resource.refetch().ignore();
       await Future<void>.delayed(const Duration(milliseconds: 150));
-      expect(loadingCalledTimes, 2);
+      expect(refreshingOnErrorTimes, 1);
+      expect(errorCalledTimes, 2);
+
+      shouldThrow = false;
+      resource.refetch().ignore();
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(refreshingOnErrorTimes, 2);
+      expect(errorCalledTimes, 2);
+      expect(dataCalledTimes, 3);
+
+      expect(loadingCalledTimes, 1);
     });
 
     test(

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -469,8 +469,8 @@ void main() {
       expect(resource.state.isReady, true);
 
       resource.state.on(
-        ready: (data, refreshing) {},
-        error: (error, stack, refreshing) {},
+        ready: (data) {},
+        error: (error, stack) {},
         loading: () {},
       );
 
@@ -497,15 +497,15 @@ void main() {
       createEffect(
         (_) {
           resource.state.on(
-            ready: (data, refreshing) {
-              if (refreshing) {
+            ready: (data) {
+              if (resource.state.isRefreshing) {
                 refreshingOnDataTimes++;
               } else {
                 dataCalledTimes++;
               }
             },
-            error: (error, stackTrace, refreshing) {
-              if (refreshing) {
+            error: (error, stackTrace) {
+              if (resource.state.isRefreshing) {
                 refreshingOnErrorTimes++;
               } else {
                 errorCalledTimes++;

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -468,12 +468,6 @@ void main() {
       expect(resource.state.asReady, isNotNull);
       expect(resource.state.isReady, true);
 
-      resource.state.on(
-        ready: (data) {},
-        error: (error, stack) {},
-        loading: () {},
-      );
-
       resource.dispose();
     });
 


### PR DESCRIPTION
This PR adds support for refreshing while in error state. Docs and tests have been updated to make use of this functionality.

If one does not want to keep displaying the error while refreshing, I guess they can create a custom function, e.g. `displayLoading`, and call it both in the `ready` and `loading` callbacks, e.g.:

```dart
ResourceBuilder(
  resource: user,
  builder: (_, userValue) {
    Widget displayLoading() {
      // ...
    }
  
    return userValue.on(
      ready: (data, refreshing) {
        if (refreshing) {
          // ... display data with CircularProgressIndicator
        } else {
          // ...
        }
      },
      error: (error, _, refreshing) {
        if (refreshing) {
          return displayLoading();
        } else {
          // ...
        }
      },
      loading: displayLoading;
      },
    );
  }
);
```

I made some small changes:
- add delay to `fetchUser` (only in example subproject), so that it is simpler to debug `ResourceBuilder`.
- use CircularProgressIndicator when `refreshing` is true, in example and docs.

What do you think of this functionality? Also, do you know why a test I marked with `// TODO: should be errorFinder(refreshing: true)` fails with `refreshing:true` (maybe it is correct so, I am not fully sure)?