### PR TITLE
[feat] hasPreviousValue getter

### DIFF
--- a/packages/solidart/lib/src/core/read_signal.dart
+++ b/packages/solidart/lib/src/core/read_signal.dart
@@ -33,6 +33,10 @@ class ReadSignal<T> extends Atom implements SignalBase<T> {
 
   final T _value;
 
+  /// Whether or not there has already been a previous value. It is especially
+  /// helpful if [T] is nullable.
+  bool hasPreviousValue = false;
+
   /// All the observers
   @internal
   final List<ObserveCallback<T>> listeners = [];

--- a/packages/solidart/lib/src/core/signal.dart
+++ b/packages/solidart/lib/src/core/signal.dart
@@ -133,8 +133,6 @@ class Signal<T> extends ReadSignal<T> {
   // Tracks the internal previous value
   T? _previousValue;
 
-  bool _hasPreviousValue = false;
-
   @override
   T get value {
     reportObserved();
@@ -158,8 +156,8 @@ class Signal<T> extends ReadSignal<T> {
 
     // store the previous value
     _previousValue = _value;
-    if (!_hasPreviousValue) {
-      _hasPreviousValue = true;
+    if (!hasPreviousValue) {
+      hasPreviousValue = true;
     }
 
     // notify with the new value
@@ -182,49 +180,6 @@ class Signal<T> extends ReadSignal<T> {
     }
     return false;
   }
-
-  /// Whether or not there has already been a previous value. It is especially
-  /// helpful if [T] is nullable.
-  ///
-  /// Note: if [T] is non-nullable, [hasPreviousValue] does not have to be used;
-  /// [previousValue] suffices.
-  ///
-  /// **Example**
-  ///
-  /// It is given the following `counter`.
-  ///
-  /// ```dart
-  /// final counter = createSignal<int?>(0);
-  /// ```
-  ///
-  /// The previous value of `counter` is required somewhere in the widget
-  /// tree. It can be retrieved safely through [hasPreviousValue].
-  ///
-  /// ```dart
-  /// if (counter.hasPreviousValue) {
-  ///   final v = counter.previousValue; // null could be a valid value
-  ///   // do some stuff based on v (valid previous value)
-  /// } else {
-  ///   // do something knowing there has not been a previous value yet
-
-  ///   // Note: counter.previousValue has to be null in this case
-  /// }
-  /// ```
-  ///
-  /// The above snippet is safer than relying only on [previousValue], as shown
-  /// in the next block.
-  ///
-  /// ```dart
-  /// final v = counter.previousValue;
-  /// if (v == null) {
-  ///   // does this mean the previous value is actually `null` (as valid
-  ///   // value), or the counter's value has not changed yet?
-  ///   // It is unclear...
-  /// } else {
-  ///   // do some stuff based on v (valid previous value)
-  /// }
-  /// ```
-  bool hasPreviousValue() => _hasPreviousValue;
 
   /// The previous value, if any.
   @override

--- a/packages/solidart/lib/src/core/signal.dart
+++ b/packages/solidart/lib/src/core/signal.dart
@@ -133,6 +133,8 @@ class Signal<T> extends ReadSignal<T> {
   // Tracks the internal previous value
   T? _previousValue;
 
+  bool _hasPreviousValue = false;
+
   @override
   T get value {
     reportObserved();
@@ -156,6 +158,9 @@ class Signal<T> extends ReadSignal<T> {
 
     // store the previous value
     _previousValue = _value;
+    if (!_hasPreviousValue) {
+      _hasPreviousValue = true;
+    }
 
     // notify with the new value
     _value = newValue;
@@ -177,6 +182,34 @@ class Signal<T> extends ReadSignal<T> {
     }
     return false;
   }
+
+  /// Whether or not there has already been a previous value. It is helpful
+  /// if [T] is nullable. Usage example:
+  ///
+  /// ```dart
+  /// if (widget.counter.hasPreviousValue) {
+  ///   final v = widget.counter.previousValue; // null could be a valid value
+  ///   // do some stuff based on v (valid previous value)
+  /// } else {
+  ///   // widget.counter.previousValue has to be null in this case
+  /// 
+  ///   // do something knowing there has not been a previous value yet
+  /// }
+  /// ```
+  /// 
+  /// which is safer than:
+  /// 
+  /// ```dart
+  /// final v = widget.counter.previousValue;
+  /// if (v == null) {
+  ///   // does this mean the previous value is actually `null` (as valid
+  ///   // value), or the counter's value has not changed yet?
+  ///   // This branch is unclear...
+  /// } else {
+  ///   // do some stuff based on v (valid previous value)
+  /// }
+  /// ```
+  bool hasPreviousValue() => _hasPreviousValue;
 
   /// The previous value, if any.
   @override

--- a/packages/solidart/lib/src/core/signal.dart
+++ b/packages/solidart/lib/src/core/signal.dart
@@ -183,28 +183,43 @@ class Signal<T> extends ReadSignal<T> {
     return false;
   }
 
-  /// Whether or not there has already been a previous value. It is helpful
-  /// if [T] is nullable. Usage example:
+  /// Whether or not there has already been a previous value. It is especially
+  /// helpful if [T] is nullable.
+  ///
+  /// Note: if [T] is non-nullable, [hasPreviousValue] does not have to be used;
+  /// [previousValue] suffices.
+  ///
+  /// **Example**
+  ///
+  /// It is given the following `counter`.
   ///
   /// ```dart
-  /// if (widget.counter.hasPreviousValue) {
-  ///   final v = widget.counter.previousValue; // null could be a valid value
+  /// final counter = createSignal<int?>(0);
+  /// ```
+  ///
+  /// The previous value of `counter` is required somewhere in the widget
+  /// tree. It can be retrieved safely through [hasPreviousValue].
+  ///
+  /// ```dart
+  /// if (counter.hasPreviousValue) {
+  ///   final v = counter.previousValue; // null could be a valid value
   ///   // do some stuff based on v (valid previous value)
   /// } else {
-  ///   // widget.counter.previousValue has to be null in this case
-  /// 
   ///   // do something knowing there has not been a previous value yet
+
+  ///   // Note: counter.previousValue has to be null in this case
   /// }
   /// ```
-  /// 
-  /// which is safer than:
-  /// 
+  ///
+  /// The above snippet is safer than relying only on [previousValue], as shown
+  /// in the next block.
+  ///
   /// ```dart
-  /// final v = widget.counter.previousValue;
+  /// final v = counter.previousValue;
   /// if (v == null) {
   ///   // does this mean the previous value is actually `null` (as valid
   ///   // value), or the counter's value has not changed yet?
-  ///   // This branch is unclear...
+  ///   // It is unclear...
   /// } else {
   ///   // do some stuff based on v (valid previous value)
   /// }


### PR DESCRIPTION
This PR adds the `hasPreviousValue` getter suggested in https://github.com/nank1ro/solidart/pull/27#issuecomment-1588990715.

It is a bit unclear to me whether or not I should make a `reportObserved` call before returning `_hasPreviousValue` (similarly to what the `previousValue` getter does).