### PR TITLE
[chore] Rename `resource` param to `state`

### DIFF
--- a/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_solidart/src/widgets/signal_builder.dart';
 import 'package:solidart/solidart.dart';
 
-/// Builder function for a [resource]
+/// Builder function for a [Resource].
 typedef ResourceWidgetBuilder<T> = Widget Function(
   BuildContext context,
-  ResourceState<T> resource,
+  ResourceState<T> state,
 );
 
 /// {@template resourcebuilder}

--- a/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
@@ -5,7 +5,7 @@ import 'package:solidart/solidart.dart';
 /// Builder function for a [Resource].
 typedef ResourceWidgetBuilder<T> = Widget Function(
   BuildContext context,
-  ResourceState<T> state,
+  ResourceState<T> resourceState,
 );
 
 /// {@template resourcebuilder}


### PR DESCRIPTION
I think that `state` is much more suitable than the current `resource`. Also, it actually is the  `resource.state` itself after all...

This will be especially helpful when using autocomplete.