### PR TITLE
[chore] Correct `Computed`'s `previousValue` getter

### DIFF
--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -151,15 +151,6 @@ class Computed<T> extends Signal<T> implements Derivation {
   @override
   bool get hasPreviousValue => _hasPreviousValue;
 
-  /// The previous value, if any.
-  @override
-  T? get previousValue {
-    final prevVal = _value;
-    // get the actual value to cause observation
-    final _ = value;
-    return _previousValue = prevVal;
-  }
-
   @override
   DisposeEffect observe(
     ObserveCallback<T> listener, {

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -151,6 +151,13 @@ class Computed<T> extends Signal<T> implements Derivation {
   @override
   bool get hasPreviousValue => _hasPreviousValue;
 
+  /// The previous value, if any.
+  @override
+  T? get previousValue {
+    reportObserved();
+    return _previousValue;
+  }
+
   @override
   DisposeEffect observe(
     ObserveCallback<T> listener, {


### PR DESCRIPTION
At the moment calling `previousValue` sets a previous value, which is unwanted. By removing this getter, the `Signal` one will be used.

I tested this manually.