### PR TITLE
[chore] Correct `Computed`'s `hasPreviousValue` getter

### DIFF
--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -81,6 +81,10 @@ class Computed<T> extends Signal<T> implements Derivation {
   // Whether or not there is a previous value
   bool _hasPreviousValue = false;
 
+  /// Used internally to determine if it is already possible to set
+  /// [_hasPreviousValue] to true
+  bool _computedFirstValue = false;
+
   @override
   // ignore: overridden_fields
   final String name;
@@ -223,7 +227,15 @@ class Computed<T> extends Signal<T> implements Derivation {
     if (changed) {
       _previousValue = oldValue;
       _value = newValue;
-      _hasPreviousValue = true;
+    }
+
+    if (_computedFirstValue) {
+      if (!_hasPreviousValue) {
+        _hasPreviousValue = true;
+        reportChanged();
+      }
+    } else {
+      _computedFirstValue = true;
     }
 
     return changed;

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -227,15 +227,12 @@ class Computed<T> extends Signal<T> implements Derivation {
     if (changed) {
       _previousValue = oldValue;
       _value = newValue;
-    }
-
-    if (_computedFirstValue) {
-      if (!_hasPreviousValue) {
+      if (_computedFirstValue) {
         _hasPreviousValue = true;
-        reportChanged();
       }
-    } else {
-      _computedFirstValue = true;
+      if (!_computedFirstValue) {
+        _computedFirstValue = true;
+      }
     }
 
     return changed;

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -229,8 +229,7 @@ class Computed<T> extends Signal<T> implements Derivation {
       _value = newValue;
       if (_computedFirstValue) {
         _hasPreviousValue = true;
-      }
-      if (!_computedFirstValue) {
+      } else {
         _computedFirstValue = true;
       }
     }


### PR DESCRIPTION
Currently, the returned value is always true, since the first time a value is set, `hasPreviousValue` is also set to true.

The PR ensures that `hasPreviousValue` returns true starting from the second time a value is — non-manually — set, i.e., the first time a value is updated.

In the first commit (fee2a4b270148b134fb281178411e0164ca1ccc8) can cause unnecessary rebuilds. The second commit (c3be4db) fixes this issue.