### PR TITLE
Feat/make resource stream react to source

### DIFF
--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.0-dev7
+
+### Changes from solidart
+
+- **FEAT** Before, only the `fetcher` reacted to the `source`.
+Now also the `stream` reacts to the `source` changes by subscribing again to the stream.
+In addition, the `stream` parameter of the Resource has been changed from `Stream` into a `Stream Function()` in order to be able to listen to a new stream if it changed
+
 ## 1.0.0-dev6
 
 ### Changes from solidart

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 1.0.0-dev6
+version: 1.0.0-dev7
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.9.1
-  solidart: ^1.0.0-dev5
+  solidart: ^1.0.0-dev6
 
 dev_dependencies:
   flutter_test:

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-dev6
+
+- **FEAT** Before, only the `fetcher` reacted to the `source`.
+Now also the `stream` reacts to the `source` changes by subscribing again to the stream.
+In addition, the `stream` parameter of the Resource has been changed from `Stream` into a `Stream Function()` in order to be able to listen to a new stream if it changed
+
 ## 1.0.0-dev5
 
 - **BUGFIX** Refactor the core of the library in order to fix issues with `previousValue` and `hasPreviousValue` of `Computed` and simplify the logic.

--- a/packages/solidart/lib/src/core/resource.dart
+++ b/packages/solidart/lib/src/core/resource.dart
@@ -23,14 +23,14 @@ class ResourceOptions {
 /// {@macro resource}
 Resource<T> createResource<T>({
   Future<T> Function()? fetcher,
-  Stream<T>? stream,
+  Stream<T> Function()? stream,
   SignalBase<dynamic>? source,
   ResourceOptions? options,
 }) {
   return Resource<T>(
     fetcher: fetcher,
-    source: source,
     stream: stream,
+    source: source,
     options: options,
   );
 }
@@ -42,12 +42,13 @@ Resource<T> createResource<T>({
 /// and __loading__.
 ///
 /// Resources can be driven by a `source` signal that provides the query to an
-/// async data `fetcher` function that returns a `Future`.
+/// async data `fetcher` function that returns a `Future` or to a `stream` that
+/// is listened again when the source changes.
 ///
 /// The contents of the `fetcher` function can be anything. You can hit typical
 /// REST endpoints or GraphQL or anything that generates a future. Resources
 /// are not opinionated on the means of loading the data, only that they are
-/// driven by futures.
+/// driven by an async operation.
 ///
 /// Let's create a Resource:
 ///
@@ -73,8 +74,6 @@ Resource<T> createResource<T>({
 /// A Resource can also be driven from a [stream] instead of a Future.
 /// In this case you just need to pass the `stream` field to the
 /// `createResource` method.
-/// The [source] field is ignored for the [stream] and used only for a
-/// [fetcher].
 ///
 /// If you are using the `flutter_solidart` library, check
 /// `ResourceBuilder` to learn how to react to the state of the resource in the
@@ -106,7 +105,8 @@ Resource<T> createResource<T>({
 /// resource.
 /// If runs the `fetcher` for the first time and then it listen to the
 /// [source], if provided.
-/// If you're passing a [stream] it subscribes to it.
+/// If you're passing a [stream] it subscribes to it, and every time the source
+/// changes, it resubscribes again.
 ///
 /// The `refetch` method forces an update and calls the `fetcher` function
 /// again.
@@ -144,7 +144,7 @@ class Resource<T> extends Signal<ResourceState<T>> {
   final ResourceOptions resourceOptions;
 
   /// The stream used to retrieve data.
-  final Stream<T>? stream;
+  final Stream<T>? Function()? stream;
   StreamSubscription<T>? _streamSubscription;
 
   /// The current resource state
@@ -154,6 +154,13 @@ class Resource<T> extends Signal<ResourceState<T>> {
   @override
   ResourceState<T> get value {
     return super.value;
+  }
+
+  // The stream trasformed in a broadcast stream, if needed
+  Stream<T> get _stream {
+    final s = stream!()!;
+    if (s.isBroadcast) return s;
+    return s.asBroadcastStream();
   }
 
   /// Resolves the [Resource].
@@ -171,16 +178,22 @@ class Resource<T> extends Signal<ResourceState<T>> {
     if (fetcher != null) {
       // start fetching
       await _fetch();
-      // react to the [source], if provided.
-
-      if (source != null) {
-        final unobserve = source!.observe((_, __) => refetch());
-        source!.onDispose(unobserve);
-      }
     }
     // React the the [stream], if provided
     if (stream != null) {
-      _listenToStream();
+      subscribe();
+    }
+
+    // react to the [source], if provided.
+    if (source != null) {
+      final unobserve = source!.observe((_, __) {
+        if (fetcher != null) {
+          refetch();
+        } else {
+          subscribe();
+        }
+      });
+      source!.onDispose(unobserve);
     }
   }
 
@@ -204,9 +217,27 @@ class Resource<T> extends Signal<ResourceState<T>> {
   }
 
   /// Starts listening to the [stream] provided.
-  void _listenToStream() {
-    value = ResourceState<T>.loading();
-    _streamSubscription = stream!.listen(
+  ///
+  /// If the stream is already listened, it cancels the previous subscription
+  /// and re-subscribes.
+  void subscribe() {
+    assert(
+      stream != null,
+      'You are trying to listen to a stream, but stream is null',
+    );
+    _streamSubscription?.cancel();
+    if (state.isReady) {
+      update(
+        (state) => (state as ResourceReady<T>).copyWith(isRefreshing: true),
+      );
+    } else if (state.hasError) {
+      update(
+        (state) => (state as ResourceError<T>).copyWith(isRefreshing: true),
+      );
+    } else {
+      value = ResourceState<T>.loading();
+    }
+    _streamSubscription = _stream.listen(
       (data) {
         value = ResourceState<T>.ready(data);
       },
@@ -222,11 +253,11 @@ class Resource<T> extends Signal<ResourceState<T>> {
     try {
       if (state is ResourceReady<T>) {
         update(
-          (value) => (value as ResourceReady<T>).copyWith(isRefreshing: true),
+          (state) => (state as ResourceReady<T>).copyWith(isRefreshing: true),
         );
       } else if (state is ResourceError<T>) {
         update(
-          (value) => (value as ResourceError<T>).copyWith(isRefreshing: true),
+          (state) => (state as ResourceError<T>).copyWith(isRefreshing: true),
         );
       } else {
         value = ResourceState<T>.loading();
@@ -253,6 +284,12 @@ class Resource<T> extends Signal<ResourceState<T>> {
   FutureOr<T> untilReady() {
     return firstWhereReady();
   }
+
+  @override
+  ResourceState<T> update(
+    ResourceState<T> Function(ResourceState<T> state) callback,
+  ) =>
+      value = callback(state);
 
   @override
   void dispose() {

--- a/packages/solidart/lib/src/core/resource.dart
+++ b/packages/solidart/lib/src/core/resource.dart
@@ -147,6 +147,9 @@ class Resource<T> extends Signal<ResourceState<T>> {
   final Stream<T>? Function()? stream;
   StreamSubscription<T>? _streamSubscription;
 
+  // The source dispose observation
+  DisposeObservation? _sourceDisposeObservation;
+
   /// The current resource state
   ResourceState<T> get state => super.value;
 
@@ -186,14 +189,14 @@ class Resource<T> extends Signal<ResourceState<T>> {
 
     // react to the [source], if provided.
     if (source != null) {
-      final unobserve = source!.observe((_, __) {
+      _sourceDisposeObservation = source!.observe((_, __) {
         if (fetcher != null) {
           refetch();
         } else {
           subscribe();
         }
       });
-      source!.onDispose(unobserve);
+      source!.onDispose(_sourceDisposeObservation!);
     }
   }
 
@@ -294,6 +297,7 @@ class Resource<T> extends Signal<ResourceState<T>> {
   @override
   void dispose() {
     _streamSubscription?.cancel();
+    _sourceDisposeObservation?.call();
     super.dispose();
   }
 

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 1.0.0-dev5
+version: 1.0.0-dev6
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -475,7 +475,6 @@ void main() {
         resource.state,
         isA<ResourceReady<int>>().having((p0) => p0.value, 'equal to 0', 0),
       );
-      expect(resource.state.value, 0);
 
       count.set(5);
       await pumpEventQueue();

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -507,7 +507,7 @@ void main() {
         return Future.value(User(id: userId()));
       }
 
-      final resource = createResource(fetcher: getUser);
+      final resource = createResource(fetcher: getUser, source: userId);
 
       await resource.resolve();
       await pumpEventQueue();

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -433,7 +433,7 @@ void main() {
       final streamController = StreamController<int>();
       addTearDown(streamController.close);
 
-      final resource = createResource(stream: streamController.stream);
+      final resource = createResource(stream: () => streamController.stream);
       expect(resource.state, isA<ResourceUnresolved<int>>());
       resource.resolve().ignore();
       expect(resource.state, isA<ResourceLoading<int>>());
@@ -451,6 +451,38 @@ void main() {
       await pumpEventQueue();
       expect(resource.state, isA<ResourceError<int>>());
       expect(resource.state.error, isUnimplementedError);
+    });
+
+    test('check createResource with stream and source', () async {
+      final count = createSignal(-1);
+
+      final resource = createResource(
+        stream: () {
+          if (count() < 1) return Stream.value(0);
+          return Stream.value(count());
+        },
+        source: count,
+        options: const ResourceOptions(lazy: false),
+      );
+
+      addTearDown(() {
+        resource.dispose();
+        count.dispose();
+      });
+
+      await pumpEventQueue();
+      expect(
+        resource.state,
+        isA<ResourceReady<int>>().having((p0) => p0.value, 'equal to 0', 0),
+      );
+      expect(resource.state.value, 0);
+
+      count.set(5);
+      await pumpEventQueue();
+      expect(
+        resource.state,
+        isA<ResourceReady<int>>().having((p0) => p0.value, 'equal to 5', 5),
+      );
     });
 
     test('check createResource with future that throws', () async {
@@ -475,7 +507,7 @@ void main() {
         return Future.value(User(id: userId()));
       }
 
-      final resource = createResource(fetcher: getUser, source: userId);
+      final resource = createResource(fetcher: getUser);
 
       await resource.resolve();
       await pumpEventQueue();


### PR DESCRIPTION
Before,  only the `fetcher` reacted to the `source`.
Now also the `stream` reacts to the `source` changes by subscribing again to the stream.

In addition, the `stream` parameter of the `Resource` has been changed from `Stream` into a `Stream Function()` in order to be able to listen to a new stream if it changed