### PR TITLE
Feat/resource selector and solid builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths-ignore:
       - "**.md"
 

--- a/README.md
+++ b/README.md
@@ -191,21 +191,18 @@ class MyApp extends StatelessWidget {
           create: () => createSignal(ThemeMode.light),
         ),
       ],
-      child:
-          // using a builder here because the `context` must be a descendant of [Solid]
-          Builder(
-        builder: (context) {
-          // observe the theme mode value this will rebuild every time the themeMode signal changes.
-          final themeMode = context.observe<ThemeMode>(); // [2]
-          return MaterialApp(
-            title: 'Toggle theme',
-            themeMode: themeMode,
-            theme: ThemeData.light(),
-            darkTheme: ThemeData.dark(),
-            home: const MyHomePage(),
-          );
-        },
-      ),
+      // using the builder method to immediately access the signal
+      builder: (context) {
+        // observe the theme mode value this will rebuild every time the themeMode signal changes.
+        final themeMode = context.observe<ThemeMode>(); // [2]
+        return MaterialApp(
+          title: 'Toggle theme',
+          themeMode: themeMode,
+          theme: ThemeData.light(),
+          darkTheme: ThemeData.dark(),
+          home: const MyHomePage(),
+        );
+      },
     );
   }
 }

--- a/docs/flutter/solid.mdx
+++ b/docs/flutter/solid.mdx
@@ -33,21 +33,18 @@ class MyApp extends StatelessWidget {
           create: () => createSignal(ThemeMode.light),
         ),
       ],
-      child:
-          // using a builder here because the `context` must be a descendant of [Solid]
-          Builder(
-        builder: (context) {
-          // observe the theme mode value this will rebuild every time the themeMode signal changes.
-          final themeMode = context.observe<ThemeMode>();
-          return MaterialApp(
-            title: 'Toggle theme',
-            themeMode: themeMode,
-            theme: ThemeData.light(),
-            darkTheme: ThemeData.dark(),
-            home: const MyHomePage(),
-          );
-        },
-      ),
+      // using the builder method to immediately access the signal
+      builder: (context) {
+        // observe the theme mode value this will rebuild every time the themeMode signal changes.
+        final themeMode = context.observe<ThemeMode>();
+        return MaterialApp(
+          title: 'Toggle theme',
+          themeMode: themeMode,
+          theme: ThemeData.light(),
+          darkTheme: ThemeData.dark(),
+          home: const MyHomePage(),
+        );
+      },
     );
   }
 }

--- a/examples/counter/pubspec.yaml
+++ b/examples/counter/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.0.0-dev902
+  flutter_solidart: ^1.0.0-dev903
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/examples/github_search/pubspec.yaml
+++ b/examples/github_search/pubspec.yaml
@@ -48,7 +48,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.1
   custom_lint: ^0.5.0
-  solidart_lint: ^1.0.0-dev4
+  solidart_lint: ^1.0.0-dev5
   json_serializable: ^6.7.0
   build_runner: ^2.4.5
 

--- a/examples/github_search/pubspec.yaml
+++ b/examples/github_search/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.0.0-dev902
+  flutter_solidart: ^1.0.0-dev903
   json_annotation: ^4.8.1
   equatable: ^2.0.5
   http: ^1.0.0

--- a/examples/todos/pubspec.yaml
+++ b/examples/todos/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.0.0-dev902
+  flutter_solidart: ^1.0.0-dev903
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/examples/todos/pubspec.yaml
+++ b/examples/todos/pubspec.yaml
@@ -43,7 +43,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  solidart_lint: ^1.0.0-dev4
+  solidart_lint: ^1.0.0-dev5
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your

--- a/examples/toggle_theme/lib/main.dart
+++ b/examples/toggle_theme/lib/main.dart
@@ -17,21 +17,18 @@ class MyApp extends StatelessWidget {
           create: () => createSignal(ThemeMode.light),
         ),
       ],
-      child:
-          // using a builder here because the `context` must be a descendant of [Solid]
-          Builder(
-        builder: (context) {
-          // observe the theme mode value this will rebuild every time the themeMode signal changes.
-          final themeMode = context.observe<ThemeMode>();
-          return MaterialApp(
-            title: 'Toggle theme',
-            themeMode: themeMode,
-            theme: ThemeData.light(),
-            darkTheme: ThemeData.dark(),
-            home: const MyHomePage(),
-          );
-        },
-      ),
+      // using the builder method to immediately access the signal
+      builder: (context) {
+        // observe the theme mode value this will rebuild every time the themeMode signal changes.
+        final themeMode = context.observe<ThemeMode>();
+        return MaterialApp(
+          title: 'Toggle theme',
+          themeMode: themeMode,
+          theme: ThemeData.light(),
+          darkTheme: ThemeData.dark(),
+          home: const MyHomePage(),
+        );
+      },
     );
   }
 }

--- a/examples/toggle_theme/pubspec.yaml
+++ b/examples/toggle_theme/pubspec.yaml
@@ -48,7 +48,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
-  solidart_lint: ^1.0.0-dev4
+  solidart_lint: ^1.0.0-dev5
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/examples/toggle_theme/pubspec.yaml
+++ b/examples/toggle_theme/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.0.0-dev902
+  flutter_solidart: ^1.0.0-dev903
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.0-dev903
 
+- **FEAT**: The `Solid` widget now acceps a `builder` method that provides a descendant context.
 - **CHORE**: The `ResourceBuilder` no longer resolves the resource, because now the `Resource` knows when to resolve automatically.
 
 ### Changes from solidart

--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.0-dev903
+
+- **CHORE**: The `ResourceBuilder` no longer resolves the resource, because now the `Resource` knows when to resolve automatically.
+
+### Changes from solidart
+
+- **FEAT**: Add the select method on the Resource class.
+The select function allows filtering the Resource's data by reading only the properties that you care about.
+The advantage is that you keep handling the loading and error states.
+- **FEAT**: Make the Resource to auto-resolve when accessing its state
+
 ## 1.0.0-dev902
 
 - **CHORE**: Deprecate the value setter in the `Resource` in favor of the state setter

--- a/packages/flutter_solidart/README.md
+++ b/packages/flutter_solidart/README.md
@@ -189,21 +189,18 @@ class MyApp extends StatelessWidget {
           create: () => createSignal(ThemeMode.light),
         ),
       ],
-      child:
-          // using a builder here because the `context` must be a descendant of [Solid]
-          Builder(
-        builder: (context) {
-          // observe the theme mode value this will rebuild every time the themeMode signal changes.
-          final themeMode = context.observe<ThemeMode>(); // [2]
-          return MaterialApp(
-            title: 'Toggle theme',
-            themeMode: themeMode,
-            theme: ThemeData.light(),
-            darkTheme: ThemeData.dark(),
-            home: const MyHomePage(),
-          );
-        },
-      ),
+      // using the builder method to immediately access the signal
+      builder: (context) {
+        // observe the theme mode value this will rebuild every time the themeMode signal changes.
+        final themeMode = context.observe<ThemeMode>(); // [2]
+        return MaterialApp(
+          title: 'Toggle theme',
+          themeMode: themeMode,
+          theme: ThemeData.light(),
+          darkTheme: ThemeData.dark(),
+          home: const MyHomePage(),
+        );
+      },
     );
   }
 }

--- a/packages/flutter_solidart/example/lib/pages/resource.dart
+++ b/packages/flutter_solidart/example/lib/pages/resource.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:http/http.dart' as http;
@@ -11,13 +13,12 @@ class ResourcePage extends StatefulWidget {
 
 class _ResourcePageState extends State<ResourcePage> {
   final userId = createSignal(1);
-  late final Resource<String> user;
 
-  @override
-  void initState() {
-    super.initState();
-    user = createResource(fetcher: fetchUser, source: userId);
-  }
+  late final user = createResource(fetcher: fetchUser, source: userId);
+
+  late final userHairColor = user.select((data) {
+    return jsonDecode(data)['hair_color'] as String;
+  });
 
   @override
   void dispose() {
@@ -29,6 +30,7 @@ class _ResourcePageState extends State<ResourcePage> {
   Future<String> fetchUser() async {
     // simulating a delay to mimic a slow HTTP request
     await Future.delayed(const Duration(seconds: 2));
+
     final response = await http.get(
       Uri.parse('https://swapi.dev/api/people/${userId.value}/'),
     );
@@ -102,6 +104,26 @@ class _ResourcePageState extends State<ResourcePage> {
                 );
               },
             ),
+            const SizedBox(height: 30),
+            const Text(
+              'You can also `select` a value from a resource, but still continuing to handle the loading and error states',
+            ),
+            ResourceBuilder(
+              resource: userHairColor,
+              builder: (context, hairColorState) {
+                return hairColorState.on(
+                  ready: (hairColor) {
+                    return ListTile(
+                      title: Text('Haircolor: $hairColor'),
+                      subtitle:
+                          Text('refreshing: ${hairColorState.isRefreshing}'),
+                    );
+                  },
+                  loading: () => const CircularProgressIndicator(),
+                  error: (error, stackTrace) => Text('$error'),
+                );
+              },
+            )
           ],
         ),
       ),

--- a/packages/flutter_solidart/example/pubspec.yaml
+++ b/packages/flutter_solidart/example/pubspec.yaml
@@ -49,7 +49,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
   custom_lint: ^0.5.0
-  solidart_lint: ^1.0.0-dev4
+  solidart_lint: ^1.0.0-dev5
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/flutter_solidart/example/pubspec.yaml
+++ b/packages/flutter_solidart/example/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  flutter_solidart: ^1.0.0-dev902
+  flutter_solidart: ^1.0.0-dev903
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
@@ -157,10 +157,6 @@ class _ResourceBuilderState<T> extends State<ResourceBuilder<T>> {
 
   void initialize() {
     effectiveResource = widget.resource;
-    // Resolve the resource if it's not resolved yet
-    if (widget.resource.state is ResourceUnresolved<T>) {
-      widget.resource.resolve();
-    }
   }
 
   @override

--- a/packages/flutter_solidart/lib/src/widgets/solid.dart
+++ b/packages/flutter_solidart/lib/src/widgets/solid.dart
@@ -39,21 +39,18 @@ part '../models/solid_element.dart';
 ///           create: () => createSignal(ThemeMode.light),
 ///         ),
 ///       ],
-///       child:
-///           // using a builder here because the `context` must be a descendant of [Solid]
-///           Builder(
-///         builder: (context) {
-///           // observe the theme mode value this will rebuild every time the themeMode signal changes.
-///           final themeMode = context.observe<ThemeMode>();
-///           return MaterialApp(
-///             title: 'Toggle theme',
-///             themeMode: themeMode,
-///             theme: ThemeData.light(),
-///             darkTheme: ThemeData.dark(),
-///             home: const MyHomePage(),
-///           );
-///         },
-///       ),
+///       // using the builder method to immediately access the signal
+///       builder: (context) {
+///         // observe the theme mode value this will rebuild every time the themeMode signal changes.
+///         final themeMode = context.observe<ThemeMode>();
+///         return MaterialApp(
+///           title: 'Toggle theme',
+///           themeMode: themeMode,
+///           theme: ThemeData.light(),
+///           darkTheme: ThemeData.dark(),
+///           home: const MyHomePage(),
+///         );
+///       },
 ///     );
 ///   }
 /// }

--- a/packages/flutter_solidart/lib/src/widgets/solid.dart
+++ b/packages/flutter_solidart/lib/src/widgets/solid.dart
@@ -254,17 +254,27 @@ class Solid extends StatefulWidget {
   /// {@macro solid}
   const Solid({
     super.key,
-    required this.child,
+    this.child,
+    this.builder,
     this.providers = const [],
-  }) : _canAutoDisposeProviders = true;
+  })  : assert(
+          (child != null) ^ (builder != null),
+          'Provide either a child or a builder',
+        ),
+        _canAutoDisposeProviders = true;
 
   /// Private constructor used internally to hide the `autoDispose` field
   const Solid._internal({
     super.key,
     this.providers = const [],
-    required this.child,
+    this.child,
+    this.builder,
     required bool autoDispose,
-  }) : _canAutoDisposeProviders = autoDispose;
+  })  : assert(
+          (child != null) ^ (builder != null),
+          'Provide either a child or a builder',
+        ),
+        _canAutoDisposeProviders = autoDispose;
 
   /// Provide a single or multiple [SolidElement]s to a new route.
   ///
@@ -289,7 +299,10 @@ class Solid extends StatefulWidget {
   }
 
   /// The widget child that gets access to the [providers].
-  final Widget child;
+  final Widget? child;
+
+  /// The widget builder that gets access to the [providers].
+  final WidgetBuilder? builder;
 
   /// All the providers provided to all the descendants of [Solid].
   final List<SolidElement<dynamic>> providers;
@@ -636,7 +649,9 @@ class SolidState extends State<Solid> {
     return _InheritedSolid(
       state: this,
       signalValues: _signalValues,
-      child: widget.child,
+      child: widget.builder != null
+          ? Builder(builder: (context) => widget.builder!(context))
+          : widget.child!,
     );
   }
 

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 1.0.0-dev902
+version: 1.0.0-dev903
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.9.1
-  solidart: ^1.0.0-dev7
+  solidart: ^1.0.0-dev8
 
 dev_dependencies:
   flutter_test:

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0-dev8
+
+- **FEAT**: Add the select method on the Resource class.
+The select function allows filtering the Resource's data by reading only the properties that you care about.
+The advantage is that you keep handling the loading and error states.
+- **FEAT**: Make the Resource to auto-resolve when accessing its state
+
 ## 1.0.0-dev7
 
 - **CHORE**: `createComputed` now returns a `Computed` class instead of a `ReadSignal`.

--- a/packages/solidart/lib/src/core/atom.dart
+++ b/packages/solidart/lib/src/core/atom.dart
@@ -23,7 +23,8 @@ class Atom {
   bool _isPendingUnobservation = false;
   DerivationState _lowestObserverState = DerivationState.notTracking;
 
-  bool isBeingObserved = false;
+  // ignore: prefer_final_fields
+  bool _isBeingObserved = false;
 
   final Set<Derivation> _observers = {};
 

--- a/packages/solidart/lib/src/core/reactive_context.dart
+++ b/packages/solidart/lib/src/core/reactive_context.dart
@@ -84,9 +84,9 @@ class ReactiveContext {
           .._isPendingUnobservation = false;
 
         if (ob._observers.isEmpty) {
-          if (ob.isBeingObserved) {
+          if (ob._isBeingObserved) {
             // if this observable had reactive observers, trigger the hooks
-            ob.isBeingObserved = false;
+            ob._isBeingObserved = false;
           }
 
           if (ob is Computed) {
@@ -134,8 +134,8 @@ class ReactiveContext {
 
     if (derivation != null) {
       derivation._newObservables!.add(atom);
-      if (!atom.isBeingObserved) {
-        atom.isBeingObserved = true;
+      if (!atom._isBeingObserved) {
+        atom._isBeingObserved = true;
       }
     }
   }

--- a/packages/solidart/lib/src/core/resource.dart
+++ b/packages/solidart/lib/src/core/resource.dart
@@ -163,6 +163,7 @@ class Resource<T> extends Signal<ResourceState<T>> {
   /// Updates the current resource state
   set state(ResourceState<T> state) => super.value = state;
 
+  // coverage:ignore-start
   @Deprecated('Use state instead')
   @override
   ResourceState<T> get value => state;
@@ -171,15 +172,24 @@ class Resource<T> extends Signal<ResourceState<T>> {
   @override
   set value(ResourceState<T> value) => state = value;
 
+  @Deprecated('Use previousState instead')
+  @override
+  ResourceState<T>? get previousValue => previousState;
+
+  /// Returns a future that completes with the value when the Resource is ready
+  /// If the resource is already ready, it completes immediately.
+  @experimental
+  @Deprecated('Use `firstWhereReady` instead')
+  FutureOr<T> untilReady() {
+    return firstWhereReady();
+  }
+  // coverage:ignore-end
+
   /// The previous resource state
   ResourceState<T>? get previousState {
     _resolveIfNeeded();
     return super.previousValue;
   }
-
-  @Deprecated('Use previousState instead')
-  @override
-  ResourceState<T>? get previousValue => previousState;
 
   // The stream trasformed in a broadcast stream, if needed
   Stream<T> get _stream {
@@ -333,14 +343,6 @@ class Resource<T> extends Signal<ResourceState<T>> {
   FutureOr<T> firstWhereReady() async {
     final state = await firstWhere((value) => value.isReady);
     return state.asReady!.value;
-  }
-
-  /// Returns a future that completes with the value when the Resource is ready
-  /// If the resource is already ready, it completes immediately.
-  @experimental
-  @Deprecated('Use `firstWhereReady` instead')
-  FutureOr<T> untilReady() {
-    return firstWhereReady();
   }
 
   @override

--- a/packages/solidart/lib/src/core/resource.dart
+++ b/packages/solidart/lib/src/core/resource.dart
@@ -356,7 +356,7 @@ class Resource<T> extends Signal<ResourceState<T>> {
 
   @override
   String toString() =>
-      '''Resource<$T>(state: $state, previousValue: $previousValue, options; $options)''';
+      '''Resource<$T>(state: $state, previousState: $previousState, options; $options)''';
 }
 
 /// Manages all the different states of a [Resource]:

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 1.0.0-dev7
+version: 1.0.0-dev8
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -434,7 +434,6 @@ void main() {
       addTearDown(streamController.close);
 
       final resource = createResource(stream: () => streamController.stream);
-      expect(resource.state, isA<ResourceUnresolved<int>>());
       resource.resolve().ignore();
       expect(resource.state, isA<ResourceLoading<int>>());
       streamController.add(1);

--- a/packages/solidart_lint/CHANGELOG.md
+++ b/packages/solidart_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-dev5
+
+- **BUGFIX**: Fix issues with the `invalid_observe_type` and `invalid_update_type` lints not linting for a dynamic type
+
 ## 1.0.0-dev4
 
 - **CHORE**: Update `flutter_solidart` dependency, update `avoid_dynamic_solid_signal` lint and remove unnecessary lints

--- a/packages/solidart_lint/example/pubspec.yaml
+++ b/packages/solidart_lint/example/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  flutter_solidart: ^1.0.0-dev902
+  flutter_solidart: ^1.0.0-dev903
 
 dev_dependencies:
   custom_lint: ^0.5.0

--- a/packages/solidart_lint/lib/src/lints/invalid_observe_type.dart
+++ b/packages/solidart_lint/lib/src/lints/invalid_observe_type.dart
@@ -23,11 +23,15 @@ class InvalidObserveType extends DartLintRule {
       (node) async {
         if (node.methodName.name == 'observe') {
           if (node.target?.staticType == null) return;
-          if (node.argumentList.arguments.isEmpty) return;
+
           final isContext =
               buildContextType.isExactlyType(node.target!.staticType!);
           if (!isContext) return;
           if (node.staticType == null) return;
+          final typeArgument = node.typeArguments?.arguments.firstOrNull?.type;
+          if (typeArgument == null) {
+            return reporter.reportErrorForNode(_code, node);
+          }
           final isSignalBase =
               signalBaseType.isAssignableFromType(node.staticType!);
           if (isSignalBase) {

--- a/packages/solidart_lint/lib/src/lints/invalid_update_type.dart
+++ b/packages/solidart_lint/lib/src/lints/invalid_update_type.dart
@@ -27,12 +27,14 @@ class InvalidUpdateType extends DartLintRule {
           final isContext =
               buildContextType.isExactlyType(node.target!.staticType!);
           if (!isContext) return;
-          final typeArgument = node.typeArgumentTypes?.firstOrNull;
-          if (typeArgument == null) return;
+          final typeArgument = node.typeArguments?.arguments.firstOrNull?.type;
+          if (typeArgument == null) {
+            return reporter.reportErrorForNode(_code, node);
+          }
           final isSignalBase =
               signalBaseType.isAssignableFromType(typeArgument);
           if (isSignalBase) {
-            reporter.reportErrorForNode(_code, node);
+            return reporter.reportErrorForNode(_code, node);
           }
         }
       },

--- a/packages/solidart_lint/pubspec.yaml
+++ b/packages/solidart_lint/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
   lints: ^2.1.0
   test: ^1.24.3
   solidart: ^1.0.0-dev1
-  flutter_solidart: ^1.0.0-dev902
+  flutter_solidart: ^1.0.0-dev903

--- a/packages/solidart_lint/pubspec.yaml
+++ b/packages/solidart_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart_lint
 description: solidart_lint is a developer tool for users of solidart, designed to help stop common issues and simplify repetitive tasks
-version: 1.0.0-dev4
+version: 1.0.0-dev5
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart
 topics:

--- a/packages/solidart_lint/pubspec.yaml
+++ b/packages/solidart_lint/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - linter
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   analyzer: ^5.12.0


### PR DESCRIPTION
- Add the `select` method on the `Resource` class. 
  The `select` function allows filtering the Resource's data by reading only the properties that you care about.
  The advantage is that you keep handling the loading and error states.
- Make the `Resource` to auto-resolve when accessing its state.
- Fix `solidart_lint` issues with `invalid_observe_type` and `invalid_update_type` not linting for dynamic
- The `Solid` widget now acceps a `builder` method that provides a descendant context.
