### PR TITLE
feat: solid maybe get

### DIFF
--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- **FEAT**: Add the method `maybeGet()` to the `Solid` widget to get a provider. If the provider can't be found, returns `null` instead of throwing like `get()` does
+
 ## 1.1.0
 
 ### Changes from solidart

--- a/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
+++ b/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
@@ -28,6 +28,31 @@ extension SolidExtensions on BuildContext {
     return Solid.get<P>(this, id);
   }
 
+  /// Tries to obtain the Provider of the given type P and [id] corresponding to
+  /// the nearest [Solid] widget.
+  ///
+  /// Throws if no such element or [Solid] widget is found.
+  ///
+  /// Calling this method is O(N) with a small constant factor where N is the
+  /// number of [Solid] ancestors needed to traverse to find the provider with
+  /// the given [id].
+  ///
+  /// If you've a single Solid widget in the whole app N is equal to 1.
+  /// If you have two Solid ancestors and the provider is present in the nearest
+  /// ancestor, N is still 1.
+  /// If you have two Solid ancestors and the provider is present in the farest
+  /// ancestor, N is 2, and so on.
+  ///
+  /// This method should not be called from State.dispose because the element
+  /// tree is no longer stable at that time.
+  ///
+  /// Doesn't listen to the provider so it won't cause the widget to rebuild.
+  ///
+  /// You may call this method inside the `initState` or `build` methods.
+  P? maybeGet<P>([Identifier? id]) {
+    return Solid.maybeGet<P>(this, id);
+  }
+
   /// Obtains the SolidElement of a Provider of the given type T and [id]
   /// corresponding to the nearest [Solid] widget.
   ///

--- a/packages/flutter_solidart/lib/src/widgets/solid.dart
+++ b/packages/flutter_solidart/lib/src/widgets/solid.dart
@@ -355,6 +355,38 @@ class Solid extends StatefulWidget {
     return _getOrCreateProvider<T>(context, id: id);
   }
 
+  /// Tries to obtain the Provider of the given type T and [id] corresponding to
+  /// the nearest [Solid] widget.
+  ///
+  /// Throws if no such element or [Solid] widget is found.
+  ///
+  /// Calling this method is O(N) with a small constant factor where N is the
+  /// number of [Solid] ancestors needed to traverse to find the provider with
+  /// the given [id].
+  ///
+  /// If you've a single Solid widget in the whole app N is equal to 1.
+  /// If you have two Solid ancestors and the provider is present in the nearest
+  /// ancestor, N is still 1.
+  /// If you have two Solid ancestors and the provider is present in the farest
+  /// ancestor, N is 2, and so on.
+  ///
+  /// This method should not be called from State.dispose because the element
+  /// tree is no longer stable at that time.
+  ///
+  /// Doesn't listen to the provider so it won't cause the widget to rebuild.
+  ///
+  /// You may call this method inside the `initState` or `build` methods.
+  static T? maybeGet<T>(BuildContext context, [Identifier? id]) {
+    try {
+      return _getOrCreateProvider<T>(context, id: id);
+    } catch (e) {
+      if (e is SolidProviderError<T>) {
+        return null;
+      }
+      rethrow;
+    }
+  }
+
   /// Obtains the SolidElement of a Provider of the given type T and [id]
   /// corresponding to the nearest [Solid] widget.
   ///

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -705,6 +705,28 @@ void main() {
     });
   });
 
+  testWidgets('Test Solid.maybeGet returns null for a not found provider',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Solid(
+            providers: [
+              SolidProvider<NameProvider>(
+                create: () => MockNameProvider('name'),
+              ),
+            ],
+            builder: (context) {
+              final numberProvider = context.maybeGet<NumberProvider>();
+              return Text(numberProvider.toString());
+            },
+          ),
+        ),
+      ),
+    );
+    expect(find.text('null'), findsOneWidget);
+  });
+
   test('DiagnosicPropertyForGeneric', () {
     final builder = DiagnosticPropertiesBuilder();
     DiagnosticPropertiesForGeneric<String>(


### PR DESCRIPTION
Add the method `maybeGet()` to the `Solid` widget to get a provider. If the provider can't be found, returns `null` instead of throwing like `get()` does