### PR TITLE
fix: update of resource shouldn't report observed

### DIFF
--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.3
+
+### Changes from solidart
+
+- **BUGFIX**: Fix the `update` method of a `Resource` that triggered `reportObserved`.
+
 ## 1.4.2
 
 Update solidart version

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 1.4.2
+version: 1.4.3
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.9.1
-  solidart: ^1.2.1
+  solidart: ^1.2.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+- **BUGFIX**: Fix the `update` method of a `Resource` that triggered `reportObserved`.
+
 ## 1.2.1
 
 - **BUGFIX**: Fix the `updateValue` method of a `Signal` that triggered `reportObserved`. (thanks to @9dan)

--- a/packages/solidart/lib/src/core/resource.dart
+++ b/packages/solidart/lib/src/core/resource.dart
@@ -377,7 +377,7 @@ class Resource<T> extends Signal<ResourceState<T>> {
   ResourceState<T> update(
     ResourceState<T> Function(ResourceState<T> state) callback,
   ) =>
-      state = callback(state);
+      state = callback(_value);
 
   @override
   void dispose() {

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 1.2.1
+version: 1.2.2
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:


### PR DESCRIPTION
The `update` method of a `Resource` shouldn't reportObserved