### PR TITLE
Bugfix/observer collections

### DIFF
--- a/examples/counter/pubspec.yaml
+++ b/examples/counter/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.6.0
+  flutter_solidart: ^1.6.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/examples/github_search/pubspec.yaml
+++ b/examples/github_search/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.6.0
+  flutter_solidart: ^1.6.1
   json_annotation: ^4.8.1
   equatable: ^2.0.5
   http: ^1.0.0

--- a/examples/todos/pubspec.yaml
+++ b/examples/todos/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.6.0
+  flutter_solidart: ^1.6.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/examples/toggle_theme/pubspec.yaml
+++ b/examples/toggle_theme/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.6.0
+  flutter_solidart: ^1.6.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.1
+
+### Changes from solidart
+
+- **BUGFIX**: The method `didUpdateSignal` of `SolidartObserver` was not triggered for collections.
+
 ## 1.6.0
 
 ### Changes from solidart

--- a/packages/flutter_solidart/example/pubspec.yaml
+++ b/packages/flutter_solidart/example/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  flutter_solidart: ^1.6.0
+  flutter_solidart: ^1.6.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 1.6.0
+version: 1.6.1
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.9.1
-  solidart: ^1.4.0
+  solidart: ^1.4.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+- **BUGFIX**: The method `didUpdateSignal` of `SolidartObserver` was not triggered for collections.
+
 ## 1.4.0
 
 - **FEAT**: Create `SolidartConfig` which you can use to customize the `autoDispose` of all the tracking system and and `observers`.

--- a/packages/solidart/lib/src/core/collections/list.dart
+++ b/packages/solidart/lib/src/core/collections/list.dart
@@ -913,5 +913,6 @@ class ListSignal<E> extends Signal<List<E>> with ListMixin<E> {
   void _notifyChanged() {
     _reportChanged();
     _notifyListeners();
+    _notifySignalUpdate();
   }
 }

--- a/packages/solidart/lib/src/core/collections/map.dart
+++ b/packages/solidart/lib/src/core/collections/map.dart
@@ -421,5 +421,6 @@ class MapSignal<K, V> extends Signal<Map<K, V>> with MapMixin<K, V> {
   void _notifyChanged() {
     _reportChanged();
     _notifyListeners();
+    _notifySignalUpdate();
   }
 }

--- a/packages/solidart/lib/src/core/collections/set.dart
+++ b/packages/solidart/lib/src/core/collections/set.dart
@@ -463,5 +463,6 @@ class SetSignal<E> extends Signal<Set<E>> with SetMixin<E> {
   void _notifyChanged() {
     _reportChanged();
     _notifyListeners();
+    _notifySignalUpdate();
   }
 }

--- a/packages/solidart/lib/src/core/resource.dart
+++ b/packages/solidart/lib/src/core/resource.dart
@@ -610,7 +610,7 @@ class ResourceSelector<Input, Output> extends Resource<Output> {
     required super.name,
   }) : super._internal(
           options: SignalOptions<ResourceState<Output>>(
-            name: resource.name,
+            name: name,
             autoDispose: resource.options.autoDispose,
           ),
           resourceOptions: resource.resourceOptions,

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:


### PR DESCRIPTION
The method `didUpdateSignal` of `SolidartObserver` was not triggered for collections.