### PR TITLE
feat/v2.0.0

### DIFF
--- a/examples/counter/lib/main.dart
+++ b/examples/counter/lib/main.dart
@@ -41,9 +41,8 @@ class _CounterPageState extends State<CounterPage> {
       ),
       body: Center(
         child: SignalBuilder(
-          signal: counter,
-          builder: (_, value, __) {
-            return Text('$value');
+          builder: (_, __) {
+            return Text(counter().toString());
           },
         ),
       ),

--- a/examples/counter/pubspec.yaml
+++ b/examples/counter/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.7.0
+  flutter_solidart: ^2.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/examples/github_search/pubspec.yaml
+++ b/examples/github_search/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.7.0
+  flutter_solidart: ^2.0.0
   json_annotation: ^4.8.1
   equatable: ^2.0.5
   http: ^1.0.0

--- a/examples/todos/lib/widgets/todos_list.dart
+++ b/examples/todos/lib/widgets/todos_list.dart
@@ -35,12 +35,11 @@ class _TodoListState extends State<TodoList> {
   @override
   Widget build(BuildContext context) {
     // rebuilds this BuildContext every time the `activeFilter` value changes
-    final activeFilter = context.observe<TodosFilter>();
-
+    final activeFilter = context.observeSignal<TodosFilter>();
     return SignalBuilder(
-      // react to the correct list of todos list
-      signal: mapFilterToTodosList(activeFilter),
-      builder: (_, todos, __) {
+      builder: (_, __) {
+        // react to the correct list of todos list
+        final todos = mapFilterToTodosList(activeFilter).value;
         return ListView.builder(
           itemCount: todos.length,
           itemBuilder: (BuildContext context, int index) {

--- a/examples/todos/lib/widgets/toolbar.dart
+++ b/examples/todos/lib/widgets/toolbar.dart
@@ -30,14 +30,14 @@ class _ToolbarState extends State<Toolbar> {
   }
 
   /// Maps the given [filter] to the correct list of todos
-  ReadSignal<int> mapFilterToTodosList(TodosFilter filter) {
+  int mapFilterToTodosCount(TodosFilter filter) {
     switch (filter) {
       case TodosFilter.all:
-        return allTodosCount;
+        return allTodosCount();
       case TodosFilter.incomplete:
-        return incompleteTodosCount;
+        return incompleteTodosCount();
       case TodosFilter.completed:
-        return completedTodosCount;
+        return completedTodosCount();
     }
   }
 
@@ -50,11 +50,10 @@ class _ToolbarState extends State<Toolbar> {
         labelColor: Colors.black,
         tabs: TodosFilter.values.map(
           (filter) {
-            final todosCount = mapFilterToTodosList(filter);
             // Each tab bar is using its specific todos count signal
             return SignalBuilder(
-              signal: todosCount,
-              builder: (context, todosCount, _) {
+              builder: (context, _) {
+                final todosCount = mapFilterToTodosCount(filter);
                 return Tab(text: '${filter.name} ($todosCount)');
               },
             );

--- a/examples/todos/pubspec.yaml
+++ b/examples/todos/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.7.0
+  flutter_solidart: ^2.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/examples/toggle_theme/lib/main.dart
+++ b/examples/toggle_theme/lib/main.dart
@@ -20,7 +20,7 @@ class MyApp extends StatelessWidget {
       // using the builder method to immediately access the signal
       builder: (context) {
         // observe the theme mode value this will rebuild every time the themeMode signal changes.
-        final themeMode = context.observe<ThemeMode>();
+        final themeMode = context.observeSignal<ThemeMode>();
         return MaterialApp(
           title: 'Toggle theme',
           themeMode: themeMode,
@@ -48,8 +48,8 @@ class MyHomePage extends StatelessWidget {
         child:
             // Listen to the theme mode signal rebuilding only the IconButton
             SignalBuilder(
-          signal: themeMode,
-          builder: (_, mode, __) {
+          builder: (_, __) {
+            final mode = themeMode();
             return IconButton(
               onPressed: () {
                 // toggle the theme mode

--- a/examples/toggle_theme/pubspec.yaml
+++ b/examples/toggle_theme/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^1.7.0
+  flutter_solidart: ^2.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,32 @@
+## 2.0.0
+
+- **CHORE**: Improved `Solid` widget performance by more than 3000% in finding ancestor providers.
+- **FEAT**: The `SignalBuilder` widget now automatically tracks the `Signal`s used in the `builder` function allowing you to react to N signals at the same time.
+  _Before_:
+  ```dart
+  SignalBuilder(
+    signal: counter,
+    builder: (context, value, child) {
+      return Text('$value');
+    },
+  ),
+  ```
+
+  _Now_:
+  ```dart
+  SignalBuilder(
+    builder: (context, child) {
+      return Text('${counter.value}');
+    },
+  ),
+  ```
+- **BREAKING CHANGE**: Removed `DualSignalBuilder` and `TripleSignalBuilder` in favor of `SignalBuilder`.
+
+
+### Changes from solidart
+
+- **CHORE**: Add `devToolsEnabled` option to manually disable the DevTools extension that defaults to `kDebugMode`
+
 ## 1.7.0
 
 ### Changes from solidart

--- a/packages/flutter_solidart/example/lib/pages/counter.dart
+++ b/packages/flutter_solidart/example/lib/pages/counter.dart
@@ -17,9 +17,8 @@ class _CounterPageState extends State<CounterPage> {
       appBar: AppBar(title: const Text('Counter')),
       body: Center(
         child: SignalBuilder(
-          signal: counter,
-          builder: (context, count, _) {
-            return Text('Counter: $count');
+          builder: (_, __) {
+            return Text('Counter: ${counter()}');
           },
         ),
       ),

--- a/packages/flutter_solidart/example/lib/pages/derived_signal.dart
+++ b/packages/flutter_solidart/example/lib/pages/derived_signal.dart
@@ -20,22 +20,16 @@ class _DerivedSignalsPageState extends State<DerivedSignalsPage> {
         title: const Text('Derived Signals'),
       ),
       body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            SignalBuilder(
-                signal: count,
-                builder: (_, value, __) {
-                  return Text('Count: $value');
-                }),
-            const SizedBox(height: 16),
-            SignalBuilder(
-                signal: doubleCount,
-                builder: (_, value, __) {
-                  return Text('Double Count: $value');
-                }),
-            const SizedBox(height: 16),
-          ],
+        child: SignalBuilder(
+          builder: (_, __) => Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Count: ${count()}'),
+              const SizedBox(height: 16),
+              Text('Double Count: ${doubleCount()}'),
+              const SizedBox(height: 16),
+            ],
+          ),
         ),
       ),
       floatingActionButton: FloatingActionButton(

--- a/packages/flutter_solidart/example/lib/pages/dual_signal_builder.dart
+++ b/packages/flutter_solidart/example/lib/pages/dual_signal_builder.dart
@@ -24,28 +24,23 @@ class _DualSignalBuilderPageState extends State<DualSignalBuilderPage> {
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            DualSignalBuilder(
-                firstSignal: counter1,
-                secondSignal: counter2,
-                builder: (_, value1, value2, __) {
-                  return ListTile(
-                    title: Text(
-                      'First counter: $value1',
-                      textAlign: TextAlign.center,
-                      style:
-                          textTheme.titleMedium!.copyWith(color: Colors.black),
-                    ),
-                    subtitle: Padding(
-                      padding: const EdgeInsets.only(top: 8),
-                      child: Text(
-                        'Second counter: $value2',
-                        textAlign: TextAlign.center,
-                        style: textTheme.titleMedium!
-                            .copyWith(color: Colors.black),
-                      ),
-                    ),
-                  );
-                }),
+            SignalBuilder(builder: (_, __) {
+              return ListTile(
+                title: Text(
+                  'First counter: ${counter1.value}',
+                  textAlign: TextAlign.center,
+                  style: textTheme.titleMedium!.copyWith(color: Colors.black),
+                ),
+                subtitle: Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    'Second counter: ${counter2.value}',
+                    textAlign: TextAlign.center,
+                    style: textTheme.titleMedium!.copyWith(color: Colors.black),
+                  ),
+                ),
+              );
+            }),
             const SizedBox(height: 16),
             Row(
               mainAxisSize: MainAxisSize.min,

--- a/packages/flutter_solidart/example/lib/pages/effects.dart
+++ b/packages/flutter_solidart/example/lib/pages/effects.dart
@@ -39,11 +39,9 @@ class _EffectsPageState extends State<EffectsPage> {
           children: [
             const Text('Check the console to see the effect printing'),
             const SizedBox(height: 16),
-            SignalBuilder(
-                signal: count,
-                builder: (context, value, __) {
-                  return Text('Count: $value');
-                }),
+            SignalBuilder(builder: (context, child) {
+              return Text('Count: ${count.value}');
+            }),
           ],
         ),
       ),

--- a/packages/flutter_solidart/example/lib/pages/list_signal.dart
+++ b/packages/flutter_solidart/example/lib/pages/list_signal.dart
@@ -39,8 +39,7 @@ class _ListSignalPageState extends State<ListSignalPage> {
           children: [
             Expanded(
               child: SignalBuilder(
-                signal: items,
-                builder: (context, items, __) {
+                builder: (context, child) {
                   return ListView.separated(
                     itemCount: items.length,
                     itemBuilder: (BuildContext context, int index) {

--- a/packages/flutter_solidart/example/lib/pages/map_signal.dart
+++ b/packages/flutter_solidart/example/lib/pages/map_signal.dart
@@ -45,8 +45,7 @@ class _MapSignalPageState extends State<MapSignalPage> {
           children: [
             Expanded(
               child: SignalBuilder(
-                signal: items,
-                builder: (context, items, __) {
+                builder: (context, child) {
                   return ListView.separated(
                     itemCount: items.length,
                     itemBuilder: (BuildContext context, int index) {

--- a/packages/flutter_solidart/example/lib/pages/set_signal.dart
+++ b/packages/flutter_solidart/example/lib/pages/set_signal.dart
@@ -39,8 +39,7 @@ class _SetSignalPageState extends State<SetSignalPage> {
           children: [
             Expanded(
               child: SignalBuilder(
-                signal: items,
-                builder: (context, items, __) {
+                builder: (context, child) {
                   return ListView.separated(
                     itemCount: items.length,
                     itemBuilder: (BuildContext context, int index) {

--- a/packages/flutter_solidart/example/lib/pages/solid/multiple_signals_page.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/multiple_signals_page.dart
@@ -70,8 +70,8 @@ class FullName extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final firstName = context.observe<String>(#firstName);
-    final lastName = context.observe<String>(#lastName);
+    final firstName = context.observeSignal<String>(#firstName);
+    final lastName = context.observeSignal<String>(#lastName);
     return ListTile(
       title: Text('First Name: $firstName'),
       subtitle: Text('LastName: $lastName'),

--- a/packages/flutter_solidart/example/lib/pages/solid/observe_signal_page.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/observe_signal_page.dart
@@ -27,7 +27,7 @@ class SomeChild extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // retrieve the count signal, this works only if you don't have another signal of type int
-    final count = context.observe<int>();
+    final count = context.observeSignal<int>();
 
     return Center(
       child: Column(

--- a/packages/flutter_solidart/example/lib/pages/solid/solid_reactivity.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/solid_reactivity.dart
@@ -77,7 +77,7 @@ class _Counter1 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final counter1 = context.observe<int>(#firstCounter);
+    final counter1 = context.observeSignal<int>(#firstCounter);
     print('build counter1');
     return Text('Counter1: $counter1');
   }
@@ -89,7 +89,7 @@ class _Counter2 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final counter2 = context.observe<int>(#secondCounter);
+    final counter2 = context.observeSignal<int>(#secondCounter);
     print('build counter2');
     return Text('Counter2: $counter2');
   }

--- a/packages/flutter_solidart/example/lib/pages/solid/solid_signals.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/solid_signals.dart
@@ -57,17 +57,15 @@ class SomeChild extends StatelessWidget {
         children: [
           // render the count value
           SignalBuilder(
-            signal: count,
-            builder: (context, value, child) {
-              return Text('count: $value');
+            builder: (context, child) {
+              return Text('count: ${count.value}');
             },
           ),
           const SizedBox(height: 8),
           // render the double count value
           SignalBuilder(
-            signal: doubleCount,
-            builder: (context, value, child) {
-              return Text('doubleCount: $value');
+            builder: (context, child) {
+              return Text('doubleCount: ${doubleCount.value}');
             },
           ),
           const SizedBox(height: 8),

--- a/packages/flutter_solidart/example/pubspec.yaml
+++ b/packages/flutter_solidart/example/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  flutter_solidart: ^1.7.0
+  flutter_solidart: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
+++ b/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
@@ -19,8 +19,58 @@ extension SolidExtensions on BuildContext {
   }
 
   /// {@macro solid.observe}
-  T observe<T>([Identifier? id]) {
-    return Solid.observe<T>(this, id);
+  T observe<T, S>([Identifier? id]) {
+    return Solid.observe<T, S>(this, id);
+  }
+
+  /// Shorthand to observe a [Signal] with the given [T] type and [id].
+  ///
+  /// Equivalent to `context.observe<T, Signal<T>>(id)`
+  T observeSignal<T>([Identifier? id]) {
+    return Solid.observe<T, Signal<T>>(this, id);
+  }
+
+  /// Shorthand to observe a [Computed] with the given [T] type and [id].
+  ///
+  /// Equivalent to `context.observe<T, Computed<T>>(id)`
+  T observeComputed<T>([Identifier? id]) {
+    return Solid.observe<T, Computed<T>>(this, id);
+  }
+
+  /// Shorthand to observe a [ReadSignal] with the given [T] type and [id].
+  ///
+  /// Equivalent to `context.observe<T, ReadSignal<T>>(id)`
+  T observeReadSignal<T>([Identifier? id]) {
+    return Solid.observe<T, ReadSignal<T>>(this, id);
+  }
+
+  /// Shorthand to observe a [ListSignal] with the given [T] type and [id].
+  ///
+  /// Equivalent to `context.observe<T, ListSignal<T>>(id)`
+  T observeListSignal<T>([Identifier? id]) {
+    return Solid.observe<T, ListSignal<T>>(this, id);
+  }
+
+  /// Shorthand to observe a [SetSignal] with the given [T] type and [id].
+  ///
+  /// Equivalent to `context.observe<T, SetSignal<T>>(id)`
+  T observeSetSignal<T>([Identifier? id]) {
+    return Solid.observe<T, SetSignal<T>>(this, id);
+  }
+
+  /// Shorthand to observe a [MapSignal] with the given types [K] and [V] and
+  /// [id].
+  ///
+  /// Equivalent to `context.observe<V, MapSignal<K, V>>(id)`
+  V observeMapSignal<K, V>([Identifier? id]) {
+    return Solid.observe<V, MapSignal<K, V>>(this, id);
+  }
+
+  /// Shorthand to observe a [Resource] with the given [T] type and [id].
+  ///
+  /// Equivalent to `context.observe<ResourceState<T>, Resource<T>>(this, id)`
+  ResourceState<T> observeResource<T>([Identifier? id]) {
+    return Solid.observe<ResourceState<T>, Resource<T>>(this, id);
   }
 
   /// {@macro solid.update}

--- a/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/resource_builder.dart
@@ -161,10 +161,9 @@ class _ResourceBuilderState<T> extends State<ResourceBuilder<T>> {
 
   @override
   Widget build(BuildContext context) {
-    return SignalBuilder<ResourceState<T>>(
-      signal: effectiveResource,
-      builder: (context, value, __) {
-        return widget.builder(context, value);
+    return SignalBuilder(
+      builder: (context, _) {
+        return widget.builder(context, effectiveResource.state);
       },
     );
   }

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 1.7.0
+version: 2.0.0
 repository: https://github.com/nank1ro/solidart
 documentation: https://docs.page/nank1ro/solidart~dev
 topics:
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.9.1
-  solidart: ^1.5.0
+  solidart: ^1.5.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -231,9 +231,8 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: SignalBuilder(
-            signal: s,
-            builder: (context, value, child) {
-              return Text('$value');
+            builder: (context, child) {
+              return Text(s().toString());
             },
           ),
         ),
@@ -253,11 +252,9 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: DualSignalBuilder(
-            firstSignal: s1,
-            secondSignal: s2,
-            builder: (context, value1, value2, child) {
-              return Text('$value1 $value2');
+          body: SignalBuilder(
+            builder: (context, child) {
+              return Text('${s1()} ${s2()}');
             },
           ),
         ),
@@ -281,12 +278,9 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: TripleSignalBuilder(
-            firstSignal: s1,
-            secondSignal: s2,
-            thirdSignal: s3,
-            builder: (context, value1, value2, value3, child) {
-              return Text('$value1 $value2 $value3');
+          body: SignalBuilder(
+            builder: (context, child) {
+              return Text('${s1()} ${s2()} ${s3()}');
             },
           ),
         ),
@@ -323,8 +317,9 @@ void main() {
               ],
               child: Builder(
                 builder: (context) {
-                  final counter = context.observe<int>('counter');
-                  final doubleCounter = context.observe<int>('double-counter');
+                  final counter = context.observeSignal<int>('counter');
+                  final doubleCounter =
+                      context.observeComputed<int>('double-counter');
                   return Text('$counter $doubleCounter');
                 },
               ),
@@ -354,7 +349,7 @@ void main() {
               ],
               child: Builder(
                 builder: (context) {
-                  final doubleCounter = context.observe<int>();
+                  final doubleCounter = context.observeComputed<int>();
                   return Text('$doubleCounter');
                 },
               ),
@@ -381,7 +376,7 @@ void main() {
               ],
               child: Builder(
                 builder: (context) {
-                  final counter = context.observe<int>();
+                  final counter = context.observeReadSignal<int>();
                   return Text('$counter');
                 },
               ),
@@ -411,7 +406,7 @@ void main() {
               ],
               child: Builder(
                 builder: (context) {
-                  final counter = context.observe<int>(#counter);
+                  final counter = context.observeReadSignal<int>(#counter);
                   return Text('$counter');
                 },
               ),
@@ -447,11 +442,9 @@ void main() {
                 final counter = context.get<Signal<int>>('counter');
                 final doubleCounter =
                     context.get<ReadSignal<int>>('double-counter');
-                return DualSignalBuilder(
-                  firstSignal: counter,
-                  secondSignal: doubleCounter,
-                  builder: (context, value1, value2, _) {
-                    return Text('$value1 $value2');
+                return SignalBuilder(
+                  builder: (context, _) {
+                    return Text('${counter()} ${doubleCounter()}');
                   },
                 );
               },
@@ -485,9 +478,8 @@ void main() {
               builder: (context) {
                 final counter = context.get<Signal<int>>('invalid-counter');
                 return SignalBuilder(
-                  signal: counter,
-                  builder: (context, value, _) {
-                    return Text('$value');
+                  builder: (context, _) {
+                    return Text(counter().toString());
                   },
                 );
               },
@@ -516,7 +508,7 @@ void main() {
               element: context.getElement<Signal<int>>('counter'),
               child: Builder(
                 builder: (innerContext) {
-                  final counter = innerContext.observe<int>('counter');
+                  final counter = innerContext.observeSignal<int>('counter');
                   return Text('Dialog counter: $counter');
                 },
               ),
@@ -569,19 +561,17 @@ void main() {
             return Solid.value(
               elements: [
                 context.getElement<Signal<int>>('counter'),
-                context.getElement<ReadSignal<int>>('double-counter'),
+                context.getElement<Computed<int>>('double-counter'),
               ],
               child: Builder(
                 builder: (innerContext) {
                   final counter = innerContext.get<Signal<int>>('counter');
                   final doubleCounter =
-                      innerContext.get<ReadSignal<int>>('double-counter');
-                  return DualSignalBuilder(
-                    firstSignal: counter,
-                    secondSignal: doubleCounter,
-                    builder: (_, value1, value2, __) {
+                      innerContext.get<Computed<int>>('double-counter');
+                  return SignalBuilder(
+                    builder: (_, __) {
                       return Text(
-                        'Dialog counter: $value1 doubleCounter: $value2',
+                        '''Dialog counter: ${counter()} doubleCounter: ${doubleCounter()}''',
                       );
                     },
                   );
@@ -968,7 +958,7 @@ void main() {
             ],
             child: Builder(
               builder: (context) {
-                final counter = context.observe<int>();
+                final counter = context.observeSignal<int>();
                 return Column(
                   children: [
                     Text('$counter'),
@@ -1069,9 +1059,8 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: SignalBuilder(
-                signal: counter,
-                builder: (_, count, __) {
-                  return Text(count.toString());
+                builder: (_, __) {
+                  return Text(counter().toString());
                 },
               ),
             ),
@@ -1092,9 +1081,8 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: SignalBuilder(
-                signal: counter,
-                builder: (_, count, __) {
-                  return Text(count.toString());
+                builder: (_, __) {
+                  return Text(counter().toString());
                 },
               ),
             ),
@@ -1116,9 +1104,8 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: SignalBuilder(
-                signal: doubleCounter,
-                builder: (_, count, __) {
-                  return Text(count.toString());
+                builder: (_, __) {
+                  return Text(doubleCounter.toString());
                 },
               ),
             ),
@@ -1142,9 +1129,8 @@ void main() {
           MaterialApp(
             home: Scaffold(
               body: SignalBuilder(
-                signal: counter,
-                builder: (_, count, __) {
-                  return Text(count.toString());
+                builder: (_, __) {
+                  return Text(counter().toString());
                 },
               ),
             ),
@@ -1196,9 +1182,8 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: SignalBuilder(
-              signal: counter,
-              builder: (_, count, __) {
-                return Text(count.toString());
+              builder: (_, __) {
+                return Text(counter().toString());
               },
             ),
           ),

--- a/packages/solidart/lib/src/core/atom.dart
+++ b/packages/solidart/lib/src/core/atom.dart
@@ -51,10 +51,7 @@ class Atom {
 
   void _removeObserver(Derivation d) {
     _observers.remove(d);
-    if (_observers.isEmpty) {
-      _context.enqueueForUnobservation(this);
-      _mayDispose();
-    }
+    _mayDispose();
   }
 
   // coverage:ignore-start

--- a/packages/solidart/lib/src/core/effect.dart
+++ b/packages/solidart/lib/src/core/effect.dart
@@ -137,7 +137,7 @@ class Effect implements ReactionInterface {
     final effectiveOptions = (options ?? EffectOptions()).copyWith(name: name);
     if (effectiveOptions.delay == null) {
       effect = Effect._internal(
-        callback: () => effect._track(() => callback(effect.dispose)),
+        callback: () => effect.track(() => callback(effect.dispose)),
         onError: onError,
         options: effectiveOptions,
       );
@@ -159,7 +159,7 @@ class Effect implements ReactionInterface {
             timer = scheduler(() {
               isScheduled = false;
               if (!effect.disposed) {
-                effect._track(() => callback(effect.dispose));
+                effect.track(() => callback(effect.dispose));
               } else {
                 // coverage:ignore-start
                 timer?.cancel();
@@ -245,7 +245,11 @@ class Effect implements ReactionInterface {
       ..runReactions();
   }
 
-  void _track(void Function() fn) {
+  /// Tracks the observables present in the given [fn] function
+  ///
+  /// This method must not be used directly.
+  @protected
+  void track(void Function() fn) {
     _context.startBatch();
 
     _isRunning = true;

--- a/packages/solidart/lib/src/core/read_signal.dart
+++ b/packages/solidart/lib/src/core/read_signal.dart
@@ -176,9 +176,16 @@ class ReadSignal<T> extends Atom implements SignalBase<T> {
   }
 
   @override
-  void _mayDispose() {
+  Future<void> _mayDispose() async {
     if (!options.autoDispose) return;
+
+    // This is a workaround because `SignalBuilder` tracks dependencies in its
+    // `build` method and for a moment (while rendering) the dependencies list
+    // is empty.
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    // }
     if (_listeners.isEmpty && _observers.isEmpty) {
+      _context.enqueueForUnobservation(this);
       dispose();
     }
   }
@@ -205,6 +212,7 @@ class ReadSignal<T> extends Atom implements SignalBase<T> {
   // coverage:ignore-end
 
   void _notifySignalCreation() {
+    if (!options.trackInDevTools) return;
     for (final obs in SolidartConfig.observers) {
       obs.didCreateSignal(this);
     }
@@ -212,6 +220,7 @@ class ReadSignal<T> extends Atom implements SignalBase<T> {
   }
 
   void _notifySignalUpdate() {
+    if (!options.trackInDevTools) return;
     for (final obs in SolidartConfig.observers) {
       obs.didUpdateSignal(this);
     }
@@ -219,6 +228,7 @@ class ReadSignal<T> extends Atom implements SignalBase<T> {
   }
 
   void _notifySignalDisposal() {
+    if (!options.trackInDevTools) return;
     for (final obs in SolidartConfig.observers) {
       obs.didDisposeSignal(this);
     }

--- a/packages/solidart/lib/src/core/signal_options.dart
+++ b/packages/solidart/lib/src/core/signal_options.dart
@@ -24,6 +24,7 @@ class SignalOptions<T> {
     this.name,
     this.equals = false,
     this.comparator = identical,
+    this.trackInDevTools = true,
     bool? autoDispose,
   }) : autoDispose = autoDispose ?? SolidartConfig.autoDispose;
 
@@ -49,6 +50,9 @@ class SignalOptions<T> {
   /// This happens automatically when there are no longer subscribers.
   /// If you set it to false, you should remember to dispose the signal manually
   final bool autoDispose;
+
+  /// Whether to track the signal in the DevTools extension, defaults to true.
+  final bool trackInDevTools;
 
   @override
   String toString() =>

--- a/packages/solidart_devtools_extension/lib/main.dart
+++ b/packages/solidart_devtools_extension/lib/main.dart
@@ -187,37 +187,33 @@ class _SignalsState extends State<Signals> {
                   const SizedBox(height: 8),
                   Row(
                     children: [
-                      SignalBuilder(
-                          signal: filterType,
-                          builder: (context, type, _) {
-                            return DropdownButton(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 4),
-                              value: type,
-                              borderRadius:
-                                  const BorderRadius.all(Radius.circular(10)),
-                              hint: const Text('Type'),
-                              icon: type == null
-                                  ? null
-                                  : IconButton(
-                                      onPressed: () => filterType.set(null),
-                                      icon: const Icon(Icons.clear),
-                                    ),
-                              items: SignalType.values
-                                  .map((e) => DropdownMenuItem(
-                                        value: e,
-                                        child: Text(e.name.capitalizeFirst()),
-                                      ))
-                                  .toList(),
-                              onChanged: filterType.set,
-                            );
-                          }),
+                      SignalBuilder(builder: (context, _) {
+                        return DropdownButton(
+                          padding: const EdgeInsets.symmetric(horizontal: 4),
+                          value: filterType(),
+                          borderRadius:
+                              const BorderRadius.all(Radius.circular(10)),
+                          hint: const Text('Type'),
+                          icon: filterType() == null
+                              ? null
+                              : IconButton(
+                                  onPressed: () => filterType.set(null),
+                                  icon: const Icon(Icons.clear),
+                                ),
+                          items: SignalType.values
+                              .map((e) => DropdownMenuItem(
+                                    value: e,
+                                    child: Text(e.name.capitalizeFirst()),
+                                  ))
+                              .toList(),
+                          onChanged: filterType.set,
+                        );
+                      }),
                       const SizedBox(width: 4),
                       SignalBuilder(
-                        signal: showDisposed,
-                        builder: (context, disposed, _) {
+                        builder: (context, _) {
                           return FilterChip(
-                            selected: disposed,
+                            selected: showDisposed(),
                             label: const Text('Disposed'),
                             onSelected: showDisposed.set,
                           );
@@ -226,95 +222,86 @@ class _SignalsState extends State<Signals> {
                     ],
                   ),
                   const SizedBox(height: 4),
-                  DualSignalBuilder(
-                    firstSignal: signals,
-                    secondSignal: filteredSignals,
-                    builder: (context, signals, filteredSignals, _) {
+                  SignalBuilder(
+                    builder: (context, _) {
                       return Text(
-                          '${filteredSignals.length} visible of ${signals.length}');
+                          '${filteredSignals().length} visible of ${signals().length}');
                     },
                   ),
                   const SizedBox(height: 8),
                   Expanded(
-                    child: SignalBuilder(
-                        signal: filteredSignals,
-                        builder: (context, filteredSignals, _) {
-                          return ListView.separated(
-                            itemCount: filteredSignals.length,
-                            itemBuilder: (BuildContext context, int index) {
-                              final entry = filteredSignals.elementAt(index);
-                              final name = entry.key;
-                              final signal = entry.value;
-                              return SignalBuilder(
-                                signal: selectedSignalName,
-                                builder: (context, selectedName, _) {
-                                  final selected = selectedName == name;
-                                  return Stack(
-                                    children: [
-                                      ListTile(
-                                        selectedTileColor:
-                                            theme.colorScheme.onSecondary,
-                                        selectedColor:
-                                            theme.colorScheme.onSurfaceVariant,
-                                        tileColor:
-                                            theme.colorScheme.surfaceVariant,
-                                        title: Text(name),
-                                        titleAlignment:
-                                            ListTileTitleAlignment.center,
-                                        trailing: selected
-                                            ? const Icon(Icons.east_rounded)
-                                            : null,
-                                        selected: selected,
-                                        subtitle: Row(
-                                          children: [
-                                            Chip(
-                                              label: Text(
-                                                signal.type.name
-                                                    .capitalizeFirst(),
-                                              ),
-                                            ),
-                                            const SizedBox(width: 4),
-                                            Chip(
-                                              label: Text(signal.valueType),
-                                            ),
-                                          ],
-                                        ),
-                                        onTap: () {
-                                          selectedSignalName.value = name;
-                                        },
-                                        shape: const RoundedRectangleBorder(
-                                          borderRadius: BorderRadius.all(
-                                            Radius.circular(10),
+                    child: SignalBuilder(builder: (context, _) {
+                      return ListView.separated(
+                        itemCount: filteredSignals().length,
+                        itemBuilder: (BuildContext context, int index) {
+                          final entry = filteredSignals().elementAt(index);
+                          final name = entry.key;
+                          final signal = entry.value;
+                          return SignalBuilder(
+                            builder: (context, _) {
+                              final selected = selectedSignalName() == name;
+                              return Stack(
+                                children: [
+                                  ListTile(
+                                    selectedTileColor:
+                                        theme.colorScheme.onSecondary,
+                                    selectedColor:
+                                        theme.colorScheme.onSurfaceVariant,
+                                    tileColor: theme.colorScheme.surfaceVariant,
+                                    title: Text(name),
+                                    titleAlignment:
+                                        ListTileTitleAlignment.center,
+                                    trailing: selected
+                                        ? const Icon(Icons.east_rounded)
+                                        : null,
+                                    selected: selected,
+                                    subtitle: Row(
+                                      children: [
+                                        Chip(
+                                          label: Text(
+                                            signal.type.name.capitalizeFirst(),
                                           ),
+                                        ),
+                                        const SizedBox(width: 4),
+                                        Chip(
+                                          label: Text(signal.valueType),
+                                        ),
+                                      ],
+                                    ),
+                                    onTap: () {
+                                      selectedSignalName.value = name;
+                                    },
+                                    shape: const RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.all(
+                                        Radius.circular(10),
+                                      ),
+                                    ),
+                                  ),
+                                  Positioned(
+                                    top: 0,
+                                    bottom: 0,
+                                    right: 0,
+                                    child: Container(
+                                      width: 10,
+                                      decoration: BoxDecoration(
+                                        color: signal.disposed
+                                            ? Colors.red
+                                            : Colors.green,
+                                        borderRadius: const BorderRadius.only(
+                                          topRight: Radius.circular(8),
+                                          bottomRight: Radius.circular(8),
                                         ),
                                       ),
-                                      Positioned(
-                                        top: 0,
-                                        bottom: 0,
-                                        right: 0,
-                                        child: Container(
-                                          width: 10,
-                                          decoration: BoxDecoration(
-                                            color: signal.disposed
-                                                ? Colors.red
-                                                : Colors.green,
-                                            borderRadius:
-                                                const BorderRadius.only(
-                                              topRight: Radius.circular(8),
-                                              bottomRight: Radius.circular(8),
-                                            ),
-                                          ),
-                                        ),
-                                      )
-                                    ],
-                                  );
-                                },
+                                    ),
+                                  )
+                                ],
                               );
                             },
-                            separatorBuilder: (_, __) =>
-                                const SizedBox(height: 8),
                           );
-                        }),
+                        },
+                        separatorBuilder: (_, __) => const SizedBox(height: 8),
+                      );
+                    }),
                   ),
                 ],
               ),
@@ -322,17 +309,16 @@ class _SignalsState extends State<Signals> {
           ),
         ),
         Expanded(
-          child: DualSignalBuilder(
-            firstSignal: filteredSignals,
-            secondSignal: selectedSignalName,
-            builder: (context, filteredSignals, selectedName, _) {
-              if (selectedName == null) return const SizedBox();
-              final signal = filteredSignals
-                  .firstWhereOrNull((element) => element.key == selectedName)
+          child: SignalBuilder(
+            builder: (context, _) {
+              if (selectedSignalName() == null) return const SizedBox();
+              final signal = filteredSignals()
+                  .firstWhereOrNull(
+                      (element) => element.key == selectedSignalName())
                   ?.value;
               if (signal == null) return const SizedBox();
               return Card(
-                key: ValueKey(selectedName),
+                key: ValueKey(selectedSignalName()),
                 child: LayoutBuilder(builder: (context, constraints) {
                   return SingleChildScrollView(
                     padding:
@@ -343,7 +329,8 @@ class _SignalsState extends State<Signals> {
                       ),
                       child: Column(
                         children: [
-                          ParameterView(name: 'name', value: selectedName),
+                          ParameterView(
+                              name: 'name', value: selectedSignalName()),
                           ParameterView(
                               name: 'type',
                               value: signal.type.name.capitalizeFirst()),

--- a/packages/solidart_lint/example/lib/main.dart
+++ b/packages/solidart_lint/example/lib/main.dart
@@ -43,8 +43,9 @@ class MyHomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     // expect_lint: missing_solid_get_type
     final myClass = context.get();
+
     // expect_lint: invalid_observe_type
-    final counter = context.observe<Signal<int>>('counter');
+    final counter = context.observeSignal<Signal<int>>('counter');
 
     return ElevatedButton(
       child: const Text('Increment'),


### PR DESCRIPTION
- **CHORE**: Improved `Solid` widget performance by more than **3000%** in finding ancestor providers.
- **FEAT**: The `SignalBuilder` widget now automatically tracks the `Signal`s used in the `builder` function allowing you to react to N signals at the same time.
  _Before_:
  ```dart
  SignalBuilder(
    signal: counter,
    builder: (context, value, child) {
      return Text('$value');
    },
  ),
  ```

  _Now_:
  ```dart
  SignalBuilder(
    builder: (context, child) {
      return Text('${counter.value}');
    },
  ),
  ```
- **BREAKING CHANGE**: Removed `DualSignalBuilder` and `TripleSignalBuilder` in favor of `SignalBuilder`.
- **BREAKING CHANGE** the `context.observe` methods (due to the performance of the `Solid` widget) now needs the type of signal
  _Before_:
  ```dart
  final counter = context.observe<int>();
  ```
  
  _Now_:
  ```dart
  final counter = context.observe<int, Signal<int>>();
  // or
  final counter = context.observeSignal<int>();
  ```
  So this change includes the new `observeSignal`, `observeReadSignal`, `observeComputed`, `observeResource`, `observeListSignal`, `observeSetSignal` and `observeMapSignal`
  
  
  ## The PR has still some problems:
  1. The auto dispose of signals happens when using `SignalBuilder` because the effect tracks the dependencies in the `build` method. This is necessary to make it performant but, for a little moment, the signals will not be watched by the `Effect`. I still need to find a way to fix this.
  2. I don't know if `context.observe<T, S>` still be exposed, due to the new specific observe methods.
  3. Still waiting for the v2 of SolidJS that may happen at the end of January 2024, this could improve the performance of the automatic tracking system significantly (https://github.com/bubblegroup/bubble-reactivity)
  