### PR TITLE
Bugfix/add custom_lint_core dependency and import it

### DIFF
--- a/packages/solidart_lint/lib/src/lints/avoid_dynamic_provider.dart
+++ b/packages/solidart_lint/lib/src/lints/avoid_dynamic_provider.dart
@@ -1,15 +1,14 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:collection/collection.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solidart_lint/src/types.dart';
-import 'package:custom_lint_core/custom_lint_core.dart' as lint_codes;
 
 class AvoidDynamicProvider extends DartLintRule {
   const AvoidDynamicProvider() : super(code: _code);
 
-  static const _code = lint_codes.LintCode(
+  static const _code = LintCode(
     name: 'avoid_dynamic_provider',
     errorSeverity: ErrorSeverity.ERROR,
     problemMessage: 'The Provider cannot be dynamic',

--- a/packages/solidart_lint/lib/src/lints/avoid_dynamic_provider.dart
+++ b/packages/solidart_lint/lib/src/lints/avoid_dynamic_provider.dart
@@ -4,11 +4,12 @@ import 'package:analyzer/error/listener.dart';
 import 'package:collection/collection.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solidart_lint/src/types.dart';
+import 'package:custom_lint_core/custom_lint_core.dart' as lint_codes;
 
 class AvoidDynamicProvider extends DartLintRule {
   const AvoidDynamicProvider() : super(code: _code);
 
-  static const _code = LintCode(
+  static const _code = lint_codes.LintCode(
     name: 'avoid_dynamic_provider',
     errorSeverity: ErrorSeverity.ERROR,
     problemMessage: 'The Provider cannot be dynamic',

--- a/packages/solidart_lint/lib/src/lints/invalid_update_type.dart
+++ b/packages/solidart_lint/lib/src/lints/invalid_update_type.dart
@@ -3,11 +3,12 @@ import 'package:collection/collection.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solidart_lint/src/types.dart';
+import 'package:custom_lint_core/custom_lint_core.dart' as lint_codes;
 
 class InvalidUpdateType extends DartLintRule {
   const InvalidUpdateType() : super(code: _code);
 
-  static const _code = LintCode(
+  static const _code = lint_codes.LintCode(
     name: 'invalid_update_type',
     errorSeverity: ErrorSeverity.ERROR,
     problemMessage: 'The update type is invalid, must not implement SignalBase',

--- a/packages/solidart_lint/lib/src/lints/invalid_update_type.dart
+++ b/packages/solidart_lint/lib/src/lints/invalid_update_type.dart
@@ -1,14 +1,13 @@
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:collection/collection.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solidart_lint/src/types.dart';
-import 'package:custom_lint_core/custom_lint_core.dart' as lint_codes;
 
 class InvalidUpdateType extends DartLintRule {
   const InvalidUpdateType() : super(code: _code);
 
-  static const _code = lint_codes.LintCode(
+  static const _code = LintCode(
     name: 'invalid_update_type',
     errorSeverity: ErrorSeverity.ERROR,
     problemMessage: 'The update type is invalid, must not implement SignalBase',

--- a/packages/solidart_lint/lib/src/lints/missing_solid_get_type.dart
+++ b/packages/solidart_lint/lib/src/lints/missing_solid_get_type.dart
@@ -3,11 +3,12 @@ import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solidart_lint/src/types.dart';
+import 'package:custom_lint_core/custom_lint_core.dart' as lint_codes;
 
 class MissingSolidGetType extends DartLintRule {
   const MissingSolidGetType() : super(code: _code);
 
-  static const _code = LintCode(
+  static const _code = lint_codes.LintCode(
     name: 'missing_solid_get_type',
     errorSeverity: ErrorSeverity.ERROR,
     problemMessage: 'Specify the provider or signal type you want to get',

--- a/packages/solidart_lint/lib/src/lints/missing_solid_get_type.dart
+++ b/packages/solidart_lint/lib/src/lints/missing_solid_get_type.dart
@@ -1,14 +1,13 @@
 import 'package:analyzer/dart/element/type.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solidart_lint/src/types.dart';
-import 'package:custom_lint_core/custom_lint_core.dart' as lint_codes;
 
 class MissingSolidGetType extends DartLintRule {
   const MissingSolidGetType() : super(code: _code);
 
-  static const _code = lint_codes.LintCode(
+  static const _code = LintCode(
     name: 'missing_solid_get_type',
     errorSeverity: ErrorSeverity.ERROR,
     problemMessage: 'Specify the provider or signal type you want to get',

--- a/packages/solidart_lint/pubspec.yaml
+++ b/packages/solidart_lint/pubspec.yaml
@@ -15,7 +15,8 @@ dependencies:
   analyzer: ^6.4.1
   analyzer_plugin: ^0.11.3
   collection: ^1.18.0
-  custom_lint_builder: ^0.6.4
+  custom_lint_builder: ^0.6.5
+  custom_lint_core: ^0.6.5
 
 dev_dependencies:
   lints: ^3.0.0

--- a/packages/solidart_lint/pubspec.yaml
+++ b/packages/solidart_lint/pubspec.yaml
@@ -15,8 +15,7 @@ dependencies:
   analyzer: ^6.4.1
   analyzer_plugin: ^0.11.3
   collection: ^1.18.0
-  custom_lint_builder: ^0.6.5
-  custom_lint_core: ^0.6.5
+  custom_lint_builder: ^0.6.4
 
 dev_dependencies:
   lints: ^3.0.0


### PR DESCRIPTION
`dart run custom_lint` does not run successfully due to import collision of the `analyzer` and `custom_lint_core` packages. They both have a `LintCode` class, but only the `custom_lint_core` is the one that `solidart_lint` directly uses.

You can also see the package doesn't pass the static analysis at the moment (https://pub.dev/packages/solidart_lint/score).