### PR TITLE
[Chore] Rename Provider-related classes

### DIFF
--- a/examples/github_search/lib/ui/search_page.dart
+++ b/examples/github_search/lib/ui/search_page.dart
@@ -9,7 +9,7 @@ class SearchPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Solid(
+    return ProviderScope(
       providers: [
         // Provide the [GithubSearchBloc] to descendants
         Provider<GithubSearchBloc>(

--- a/examples/todos/lib/todos_page.dart
+++ b/examples/todos/lib/todos_page.dart
@@ -10,7 +10,7 @@ class TodosPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Using Provider here to provide the [TodosController] to descendants.
-    return Solid(
+    return ProviderScope(
       providers: [
         Provider<TodosController>(
           create: () => TodosController(initialTodos: Todo.sample),

--- a/examples/todos/lib/widgets/todos_body.dart
+++ b/examples/todos/lib/widgets/todos_body.dart
@@ -27,7 +27,7 @@ class _TodosBodyState extends State<TodosBody> {
     // in both the `initState` and `build` methods.
     final todosController = context.get<TodosController>();
 
-    return Solid(
+    return ProviderScope(
       providers: [
         // make the active filter signal visible only to descendants.
         // created here because this is where it starts to be necessary.

--- a/examples/todos/test/widget_test.dart
+++ b/examples/todos/test/widget_test.dart
@@ -20,7 +20,7 @@ Widget wrapWithMockedTodosController({
   required TodosController todosController,
 }) {
   return MaterialApp(
-    home: Solid(
+    home: ProviderScope(
       providers: [
         Provider<TodosController>(
           create: () => todosController,

--- a/examples/toggle_theme/lib/main.dart
+++ b/examples/toggle_theme/lib/main.dart
@@ -11,7 +11,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Provide the theme mode signal to descendats
-    return Solid(
+    return ProviderScope.builder(
       providers: [
         Provider<Signal<ThemeMode>>(
           create: () => Signal(ThemeMode.light),

--- a/packages/flutter_solidart/example/lib/pages/solid/multiple_signals_page.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/multiple_signals_page.dart
@@ -11,7 +11,7 @@ class MultipleSignalsPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Multiple Signals'),
       ),
-      body: Solid(
+      body: ProviderScope(
         providers: [
           // provide the firstName signal to descendants
           Provider<Signal<String>>(

--- a/packages/flutter_solidart/example/lib/pages/solid/observe_signal_page.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/observe_signal_page.dart
@@ -10,7 +10,7 @@ class ObserveSignalPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Observe Signal'),
       ),
-      body: Solid(
+      body: ProviderScope(
         providers: [
           // provide the count signal to descendants
           Provider<Signal<int>>(create: () => Signal(0)),

--- a/packages/flutter_solidart/example/lib/pages/solid/solid_providers.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/solid_providers.dart
@@ -26,7 +26,7 @@ class ProvidersPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Providers'),
       ),
-      body: Solid(
+      body: ProviderScope(
         providers: [
           Provider<NameProvider>(
             create: () => const NameProvider('Ale'),
@@ -58,7 +58,7 @@ class SomeChild extends StatelessWidget {
   Future<void> openDialog(BuildContext context) {
     return showDialog(
       context: context,
-      builder: (_) => Solid.value(
+      builder: (_) => ProviderScope.value(
         elements: [
           context.getElement<NameProvider>(),
           context.getElement<NumberProvider>(#firstNumber),

--- a/packages/flutter_solidart/example/lib/pages/solid/solid_reactivity.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/solid_reactivity.dart
@@ -13,7 +13,7 @@ class SolidReactivityPage extends StatefulWidget {
 class _SolidReactivityPageState extends State<SolidReactivityPage> {
   @override
   Widget build(BuildContext context) {
-    return Solid(
+    return ProviderScope(
       providers: [
         Provider<Signal<int>>(create: () => Signal(0), id: #firstCounter),
         Provider<Signal<int>>(create: () => Signal(0), id: #secondCounter),

--- a/packages/flutter_solidart/example/lib/pages/solid/solid_signals.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/solid_signals.dart
@@ -23,7 +23,7 @@ class _SolidSignalsPageState extends State<SolidSignalsPage> {
       appBar: AppBar(
         title: const Text('Solid Signals'),
       ),
-      body: Solid(
+      body: ProviderScope(
         providers: [
           // provide the count signal to descendants
           Provider<Signal<int>>(

--- a/packages/flutter_solidart/lib/flutter_solidart.dart
+++ b/packages/flutter_solidart/lib/flutter_solidart.dart
@@ -3,6 +3,7 @@ library flutter_solidart;
 
 export 'package:solidart/solidart.dart';
 
+export 'src/models/provider_context.dart';
 export 'src/utils/extensions.dart';
 export 'src/utils/solid_extensions.dart';
 export 'src/widgets/show.dart';

--- a/packages/flutter_solidart/lib/src/models/solid_element.dart
+++ b/packages/flutter_solidart/lib/src/models/solid_element.dart
@@ -9,12 +9,12 @@ typedef DisposeValue<T> = void Function(T value);
 /// The idenfifier of the element.
 typedef Identifier = Object;
 
-/// {@template solidelement}
+/// {@template provider-element}
 /// The base class of a solid provider
 /// {@endtemplate}
-abstract class SolidElement<T> {
-  /// {@macro solidelement}
-  const SolidElement({
+abstract class ProviderElement<T> {
+  /// {@macro provider-element}
+  const ProviderElement({
     required this.create,
     this.id,
   });
@@ -29,7 +29,7 @@ abstract class SolidElement<T> {
   /// Returns the type of the value
   Type get _valueType => T;
 
-  bool get _isSignal => this is SolidElement<SignalBase>;
+  bool get _isSignal => this is ProviderElement<SignalBase>;
 
   void _disposeFn(BuildContext context, dynamic value);
 }
@@ -42,7 +42,7 @@ typedef SolidProvider<T> = Provider<T>;
 
 /// {@template provider}
 /// A Provider that manages the lifecycle of the value it provides by
-// delegating to a pair of [create] and [dispose].
+/// delegating to a pair of [create] and [dispose].
 ///
 /// It is usually used to avoid making a StatefulWidget for something trivial,
 /// such as instantiating a BLoC.
@@ -61,7 +61,7 @@ typedef SolidProvider<T> = Provider<T>;
 ///
 /// {@endtemplate}
 @immutable
-class Provider<T> extends SolidElement<T> {
+class Provider<T> extends ProviderElement<T> {
   /// {@macro provider}
   const Provider({
     required super.create,

--- a/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
+++ b/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
@@ -1,30 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
-/// Convenience extensions to interact with the [Solid] InheritedModel.
-extension SolidExtensions on BuildContext {
-  /// {@macro solid.get}
+/// Convenience extensions to interact with the [ProviderScope] InheritedModel.
+extension ProviderExtensions on BuildContext {
+  /// {@macro provider-scope.get}
   P get<P>([Identifier? id]) {
-    return Solid.get<P>(this, id);
+    return ProviderScope.get<P>(this, id);
   }
 
-  /// {@macro solid.maybeGet}
+  /// {@macro provider-scope.maybeGet}
   P? maybeGet<P>([Identifier? id]) {
-    return Solid.maybeGet<P>(this, id);
+    return ProviderScope.maybeGet<P>(this, id);
   }
 
-  /// {@macro solid.getElement}
-  SolidElement<P> getElement<P>([Identifier? id]) {
-    return Solid.getElement<P>(this, id);
+  /// {@macro provider-scope.getElement}
+  ProviderElement<P> getElement<P>([Identifier? id]) {
+    return ProviderScope.getElement<P>(this, id);
   }
 
-  /// {@macro solid.observe}
+  /// {@macro provider-scope.observe}
   T observe<T extends SignalBase<dynamic>>([Identifier? id]) {
-    return Solid.observe<T>(this, id);
+    return ProviderScope.observe<T>(this, id);
   }
 
-  /// {@macro solid.update}
+  /// {@macro provider-scope.update}
   void update<T>(T Function(T value) callback, [Identifier? id]) {
-    return Solid.update<T>(this, callback, id);
+    return ProviderScope.update<T>(this, callback, id);
   }
 }

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -307,7 +307,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<Signal<int>>(create: () => s, id: 'counter'),
                 Provider<Computed<int>>(
@@ -339,7 +339,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<Computed<int>>(
                   create: () => Computed(() => s() * 2),
@@ -366,7 +366,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<ReadSignal<int>>(create: s.toReadSignal),
               ],
@@ -391,7 +391,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<ReadSignal<int>>(
                   create: s.toReadSignal,
@@ -422,7 +422,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<Signal<int>>(create: () => s, id: 'counter'),
               Provider<ReadSignal<int>>(
@@ -458,7 +458,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<Signal<int>>(
                 create: () => Signal(0),
@@ -493,7 +493,7 @@ void main() {
         return showDialog(
           context: context,
           builder: (dialogContext) {
-            return Solid.value(
+            return ProviderScope.value(
               element: context.getElement<Signal<int>>('counter'),
               child: Builder(
                 builder: (innerContext) {
@@ -511,7 +511,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<Signal<int>>(create: () => s, id: 'counter'),
               ],
@@ -546,8 +546,8 @@ void main() {
         return showDialog(
           context: context,
           builder: (dialogContext) {
-            return Solid.value(
-              elements: [
+            return ProviderScope(
+              providers: [
                 context.getElement<Signal<int>>('counter'),
                 context.getElement<Computed<int>>('double-counter'),
               ],
@@ -574,7 +574,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<Signal<int>>(
                   create: () => s,
@@ -617,7 +617,7 @@ void main() {
         return showDialog(
           context: context,
           builder: (dialogContext) {
-            return Solid.value(
+            return ProviderScope.value(
               element: context.getElement<NumberProvider>(),
               child: Builder(
                 builder: (innerContext) {
@@ -633,7 +633,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<NumberProvider>(
                   create: () => const NumberProvider(1),
@@ -667,7 +667,7 @@ void main() {
         return showDialog(
           context: context,
           builder: (dialogContext) {
-            return Solid.value(
+            return ProviderScope.value(
               element: context.getElement<NumberProvider>(),
               child: Builder(
                 builder: (innerContext) {
@@ -683,7 +683,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<NameProvider>(
                   create: () => MockNameProvider('name'),
@@ -716,7 +716,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<NameProvider>(
                 create: () => MockNameProvider('name'),
@@ -812,7 +812,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<NameProvider>(
                 create: () => nameProvider,
@@ -859,7 +859,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<NumberProvider>(
                 create: () => const NumberProvider(1),
@@ -889,7 +889,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope(
             providers: [
               Provider(create: () => const NumberProvider(1)),
             ],
@@ -910,7 +910,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope(
             providers: [
               Provider<NumberProvider>(
                 create: () => const NumberProvider(1),
@@ -934,7 +934,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<Signal<int>>(create: () => Signal(0)),
             ],
@@ -994,7 +994,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope(
             providers: [
               Provider<NumberProvider>(
                 create: () => const NumberProvider(1),
@@ -1002,7 +1002,7 @@ void main() {
                 id: 1,
               ),
             ],
-            child: Solid(
+            child: ProviderScope.builder(
               providers: [
                 Provider<NumberProvider>(
                   create: () => const NumberProvider(100),

--- a/packages/solidart_lint/example/lib/main.dart
+++ b/packages/solidart_lint/example/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Solid(
+    return ProviderScope(
       providers: [
         // expect_lint: avoid_dynamic_provider
         Provider(create: () => MyClass()),


### PR DESCRIPTION
I think the name `Solid` for the widget is a bit general/unclear. We should use something more clear like `ProviderScope`. The same concept holds for `SolidElement`, which is now `ProviderElement`. I still need to change them throughout the code base and the documentation, and rename the files. But what do you think? If you like my suggestions then I'll happily adapt them everywhere :)

Do you have a better name for `ProviderScope.value`? Maybe `ProviderScope.separate`, which hints at a separate tree?

I added some constructors to it to make them more type safe (a bit like the other PR that just got merged).