### PR TITLE
[Feature] provider context

### DIFF
--- a/examples/github_search/lib/ui/search_page.dart
+++ b/examples/github_search/lib/ui/search_page.dart
@@ -9,7 +9,7 @@ class SearchPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Solid(
+    return ProviderScope(
       providers: [
         // Provide the [GithubSearchBloc] to descendants
         Provider<GithubSearchBloc>(

--- a/examples/todos/lib/todos_page.dart
+++ b/examples/todos/lib/todos_page.dart
@@ -10,7 +10,7 @@ class TodosPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Using Provider here to provide the [TodosController] to descendants.
-    return Solid(
+    return ProviderScope(
       providers: [
         Provider<TodosController>(
           create: () => TodosController(initialTodos: Todo.sample),

--- a/examples/todos/lib/widgets/todos_body.dart
+++ b/examples/todos/lib/widgets/todos_body.dart
@@ -27,7 +27,7 @@ class _TodosBodyState extends State<TodosBody> {
     // in both the `initState` and `build` methods.
     final todosController = context.get<TodosController>();
 
-    return Solid(
+    return ProviderScope(
       providers: [
         // make the active filter signal visible only to descendants.
         // created here because this is where it starts to be necessary.

--- a/examples/todos/test/widget_test.dart
+++ b/examples/todos/test/widget_test.dart
@@ -20,7 +20,7 @@ Widget wrapWithMockedTodosController({
   required TodosController todosController,
 }) {
   return MaterialApp(
-    home: Solid(
+    home: ProviderScope(
       providers: [
         Provider<TodosController>(
           create: () => todosController,

--- a/examples/toggle_theme/lib/main.dart
+++ b/examples/toggle_theme/lib/main.dart
@@ -11,7 +11,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Provide the theme mode signal to descendats
-    return Solid(
+    return ProviderScope.builder(
       providers: [
         Provider<Signal<ThemeMode>>(
           create: () => Signal(ThemeMode.light),

--- a/packages/flutter_solidart/example/lib/pages/solid/multiple_signals_page.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/multiple_signals_page.dart
@@ -11,7 +11,7 @@ class MultipleSignalsPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Multiple Signals'),
       ),
-      body: Solid(
+      body: ProviderScope(
         providers: [
           // provide the firstName signal to descendants
           Provider<Signal<String>>(

--- a/packages/flutter_solidart/example/lib/pages/solid/observe_signal_page.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/observe_signal_page.dart
@@ -10,7 +10,7 @@ class ObserveSignalPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Observe Signal'),
       ),
-      body: Solid(
+      body: ProviderScope(
         providers: [
           // provide the count signal to descendants
           Provider<Signal<int>>(create: () => Signal(0)),

--- a/packages/flutter_solidart/example/lib/pages/solid/solid_providers.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/solid_providers.dart
@@ -26,7 +26,7 @@ class ProvidersPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Providers'),
       ),
-      body: Solid(
+      body: ProviderScope(
         providers: [
           Provider<NameProvider>(
             create: () => const NameProvider('Ale'),
@@ -58,7 +58,7 @@ class SomeChild extends StatelessWidget {
   Future<void> openDialog(BuildContext context) {
     return showDialog(
       context: context,
-      builder: (_) => Solid.value(
+      builder: (_) => ProviderScope.value(
         elements: [
           context.getElement<NameProvider>(),
           context.getElement<NumberProvider>(#firstNumber),

--- a/packages/flutter_solidart/example/lib/pages/solid/solid_reactivity.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/solid_reactivity.dart
@@ -13,7 +13,7 @@ class SolidReactivityPage extends StatefulWidget {
 class _SolidReactivityPageState extends State<SolidReactivityPage> {
   @override
   Widget build(BuildContext context) {
-    return Solid(
+    return ProviderScope(
       providers: [
         Provider<Signal<int>>(create: () => Signal(0), id: #firstCounter),
         Provider<Signal<int>>(create: () => Signal(0), id: #secondCounter),

--- a/packages/flutter_solidart/example/lib/pages/solid/solid_signals.dart
+++ b/packages/flutter_solidart/example/lib/pages/solid/solid_signals.dart
@@ -23,7 +23,7 @@ class _SolidSignalsPageState extends State<SolidSignalsPage> {
       appBar: AppBar(
         title: const Text('Solid Signals'),
       ),
-      body: Solid(
+      body: ProviderScope(
         providers: [
           // provide the count signal to descendants
           Provider<Signal<int>>(

--- a/packages/flutter_solidart/lib/flutter_solidart.dart
+++ b/packages/flutter_solidart/lib/flutter_solidart.dart
@@ -3,6 +3,7 @@ library flutter_solidart;
 
 export 'package:solidart/solidart.dart';
 
+export 'src/models/provider_context.dart';
 export 'src/utils/extensions.dart';
 export 'src/utils/solid_extensions.dart';
 export 'src/widgets/show.dart';

--- a/packages/flutter_solidart/lib/src/models/provider_context.dart
+++ b/packages/flutter_solidart/lib/src/models/provider_context.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+/// {@template provider-context}
+/// A [ProviderContext] is a type-safe identifier for [Provider]s.
+///
+/// To use [ProviderExtensions.observeByCtx] or [ProviderExtensions.updateByCtx]
+/// with this provider context, the type [T] must be a [SignalBase].
+///
+/// A [ProviderContext] is the equivalent of a
+/// [Context in SolidJS](https://docs.solidjs.com/concepts/context).
+/// {@endtemplate}
+class ProviderContext<T> {
+  /// {@macro provider-context}
+  const ProviderContext();
+}

--- a/packages/flutter_solidart/lib/src/models/solid_element.dart
+++ b/packages/flutter_solidart/lib/src/models/solid_element.dart
@@ -9,12 +9,12 @@ typedef DisposeValue<T> = void Function(T value);
 /// The idenfifier of the element.
 typedef Identifier = Object;
 
-/// {@template solidelement}
+/// {@template provider-element}
 /// The base class of a solid provider
 /// {@endtemplate}
-abstract class SolidElement<T> {
-  /// {@macro solidelement}
-  const SolidElement({
+abstract class ProviderElement<T> {
+  /// {@macro provider-element}
+  const ProviderElement({
     required this.create,
     this.id,
   });
@@ -29,7 +29,7 @@ abstract class SolidElement<T> {
   /// Returns the type of the value
   Type get _valueType => T;
 
-  bool get _isSignal => this is SolidElement<SignalBase>;
+  bool get _isSignal => this is ProviderElement<SignalBase>;
 
   void _disposeFn(BuildContext context, dynamic value);
 }
@@ -42,7 +42,7 @@ typedef SolidProvider<T> = Provider<T>;
 
 /// {@template provider}
 /// A Provider that manages the lifecycle of the value it provides by
-// delegating to a pair of [create] and [dispose].
+/// delegating to a pair of [create] and [dispose].
 ///
 /// It is usually used to avoid making a StatefulWidget for something trivial,
 /// such as instantiating a BLoC.
@@ -61,7 +61,7 @@ typedef SolidProvider<T> = Provider<T>;
 ///
 /// {@endtemplate}
 @immutable
-class Provider<T> extends SolidElement<T> {
+class Provider<T> extends ProviderElement<T> {
   /// {@macro provider}
   const Provider({
     required super.create,

--- a/packages/flutter_solidart/lib/src/models/solid_element.dart
+++ b/packages/flutter_solidart/lib/src/models/solid_element.dart
@@ -70,6 +70,14 @@ class Provider<T> extends ProviderElement<T> {
     super.id,
   });
 
+  /// {@macro provider}
+  const Provider.context(
+    ProviderContext<T> context, {
+    required super.create,
+    this.dispose,
+    this.lazy = true,
+  }) : super(id: context);
+
   /// An optional dispose function called when the Solid that created this
   /// provider disposes
   final DisposeValue<T>? dispose;

--- a/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
+++ b/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
@@ -1,30 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
-/// Convenience extensions to interact with the [Solid] InheritedModel.
-extension SolidExtensions on BuildContext {
-  /// {@macro solid.get}
+/// Convenience extensions to interact with the [ProviderScope] InheritedModel.
+extension ProviderExtensions on BuildContext {
+  /// {@macro provider-scope.get}
   P get<P>([Identifier? id]) {
-    return Solid.get<P>(this, id);
+    return ProviderScope.get<P>(this, id);
   }
 
-  /// {@macro solid.maybeGet}
+  /// {@macro provider-scope.maybeGet}
   P? maybeGet<P>([Identifier? id]) {
-    return Solid.maybeGet<P>(this, id);
+    return ProviderScope.maybeGet<P>(this, id);
   }
 
-  /// {@macro solid.getElement}
-  SolidElement<P> getElement<P>([Identifier? id]) {
-    return Solid.getElement<P>(this, id);
+  /// {@macro provider-scope.getElement}
+  ProviderElement<P> getElement<P>([Identifier? id]) {
+    return ProviderScope.getElement<P>(this, id);
   }
 
-  /// {@macro solid.observe}
+  /// {@macro provider-scope.observe}
   T observe<T extends SignalBase<dynamic>>([Identifier? id]) {
-    return Solid.observe<T>(this, id);
+    return ProviderScope.observe<T>(this, id);
   }
 
-  /// {@macro solid.update}
+  /// {@macro provider-scope.update}
   void update<T>(T Function(T value) callback, [Identifier? id]) {
-    return Solid.update<T>(this, callback, id);
+    return ProviderScope.update<T>(this, callback, id);
   }
 }

--- a/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
+++ b/packages/flutter_solidart/lib/src/utils/solid_extensions.dart
@@ -8,23 +8,67 @@ extension ProviderExtensions on BuildContext {
     return ProviderScope.get<P>(this, id);
   }
 
+  /// {@macro provider-scope.get}
+  P getByCtx<P>(ProviderContext<P> providerContext) => get<P>(providerContext);
+
   /// {@macro provider-scope.maybeGet}
   P? maybeGet<P>([Identifier? id]) {
     return ProviderScope.maybeGet<P>(this, id);
   }
+
+  /// {@macro provider-scope.maybeGet}
+  P? maybeGetByCtx<P>(ProviderContext<P> providerContext) =>
+      maybeGet<P>(providerContext);
 
   /// {@macro provider-scope.getElement}
   ProviderElement<P> getElement<P>([Identifier? id]) {
     return ProviderScope.getElement<P>(this, id);
   }
 
+  /// {@macro provider-scope.getElement}
+  ProviderElement<P> getElementByCtx<P>(ProviderContext<P> providerContext) =>
+      getElement<P>(providerContext);
+
   /// {@macro provider-scope.observe}
   T observe<T extends SignalBase<dynamic>>([Identifier? id]) {
     return ProviderScope.observe<T>(this, id);
   }
 
+  /// {@macro provider-scope.observe}
+  T observeByCtx<T extends SignalBase<dynamic>>(
+    ProviderContext<T> providerContext,
+  ) =>
+      observe<T>(providerContext);
+
   /// {@macro provider-scope.update}
   void update<T>(T Function(T value) callback, [Identifier? id]) {
     return ProviderScope.update<T>(this, callback, id);
   }
+
+  /// Convenience method to update a `Signal` value.
+  ///
+  /// You can use it to update a signal value, e.g:
+  /// ```dart
+  /// const myCounter = ProviderContext<Signal<int>>();
+  ///
+  /// // some function inside some widget
+  /// someFn(BuildContext context) {
+  ///   context.updateByCtx(myCounter, (value) => value * 2);
+  /// }
+  /// ```
+  /// This is equal to:
+  /// ```dart
+  /// // retrieve the signal
+  /// final signal = context.getByCtx(myCounter);
+  /// // update the signal
+  /// signal.update((value) => value * 2);
+  /// ```
+  /// but shorter when you don't need the signal for anything else.
+  ///
+  /// WARNING: Supports only the `Signal` type
+  void updateByCtx<T>(
+    T Function(T value) callback,
+    ProviderContext<T> providerContext,
+  ) =>
+      update(callback, providerContext);
 }

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -307,7 +307,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<Signal<int>>(create: () => s, id: 'counter'),
                 Provider<Computed<int>>(
@@ -339,7 +339,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<Computed<int>>(
                   create: () => Computed(() => s() * 2),
@@ -366,7 +366,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<ReadSignal<int>>(create: s.toReadSignal),
               ],
@@ -391,7 +391,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<ReadSignal<int>>(
                   create: s.toReadSignal,
@@ -422,7 +422,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<Signal<int>>(create: () => s, id: 'counter'),
               Provider<ReadSignal<int>>(
@@ -458,7 +458,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<Signal<int>>(
                 create: () => Signal(0),
@@ -493,7 +493,7 @@ void main() {
         return showDialog(
           context: context,
           builder: (dialogContext) {
-            return Solid.value(
+            return ProviderScope.value(
               element: context.getElement<Signal<int>>('counter'),
               child: Builder(
                 builder: (innerContext) {
@@ -511,7 +511,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<Signal<int>>(create: () => s, id: 'counter'),
               ],
@@ -546,8 +546,8 @@ void main() {
         return showDialog(
           context: context,
           builder: (dialogContext) {
-            return Solid.value(
-              elements: [
+            return ProviderScope(
+              providers: [
                 context.getElement<Signal<int>>('counter'),
                 context.getElement<Computed<int>>('double-counter'),
               ],
@@ -574,7 +574,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<Signal<int>>(
                   create: () => s,
@@ -617,7 +617,7 @@ void main() {
         return showDialog(
           context: context,
           builder: (dialogContext) {
-            return Solid.value(
+            return ProviderScope.value(
               element: context.getElement<NumberProvider>(),
               child: Builder(
                 builder: (innerContext) {
@@ -633,7 +633,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<NumberProvider>(
                   create: () => const NumberProvider(1),
@@ -667,7 +667,7 @@ void main() {
         return showDialog(
           context: context,
           builder: (dialogContext) {
-            return Solid.value(
+            return ProviderScope.value(
               element: context.getElement<NumberProvider>(),
               child: Builder(
                 builder: (innerContext) {
@@ -683,7 +683,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Solid(
+            body: ProviderScope.builder(
               providers: [
                 Provider<NameProvider>(
                   create: () => MockNameProvider('name'),
@@ -716,7 +716,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<NameProvider>(
                 create: () => MockNameProvider('name'),
@@ -812,7 +812,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<NameProvider>(
                 create: () => nameProvider,
@@ -859,7 +859,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<NumberProvider>(
                 create: () => const NumberProvider(1),
@@ -889,7 +889,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope(
             providers: [
               Provider(create: () => const NumberProvider(1)),
             ],
@@ -910,7 +910,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope(
             providers: [
               Provider<NumberProvider>(
                 create: () => const NumberProvider(1),
@@ -934,7 +934,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope.builder(
             providers: [
               Provider<Signal<int>>(create: () => Signal(0)),
             ],
@@ -994,7 +994,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: Solid(
+          body: ProviderScope(
             providers: [
               Provider<NumberProvider>(
                 create: () => const NumberProvider(1),
@@ -1002,7 +1002,7 @@ void main() {
                 id: 1,
               ),
             ],
-            child: Solid(
+            child: ProviderScope.builder(
               providers: [
                 Provider<NumberProvider>(
                   create: () => const NumberProvider(100),

--- a/packages/solidart_lint/example/lib/main.dart
+++ b/packages/solidart_lint/example/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Solid(
+    return ProviderScope(
       providers: [
         // expect_lint: avoid_dynamic_provider
         Provider(create: () => MyClass()),


### PR DESCRIPTION
This PR introduces ProviderContexts, which are IDs with first class support. It allows providers to be typesafe. They are similar to createContext/useContext in Solid.js.

They can still throw if absent while injecting them, but at least the creation and the injection can be done in a typesafe way.

More examples and tests are needed. I also did not test them manually yet, but this is a first draft and I was excited to show it.

NB: it might be easiest to look at the differences by looking at the last commit. While I was working on this, I was also renaming Provider-related classes, constructors, ...

```dart
  // the context (the id is global
  const myCounter = ProviderContext<Signal<int>>();

 // add it with a ProviderScope
 ProviderScope(
   providers: [ Provider.context(myCounter, create: ...) ],
   child: ...
 )
   
  // some function inside some widget
  someFn(BuildContext context) {
    context.updateByCtx(myCounter, (value) => value * 2);
  }
```

This is equal to:

```dart
// retrieve the signal
final signal = context.getByCtx(myCounter);
// update the signal
signal.update((value) => value * 2);
```