### PR TITLE
Create Maybe types

### DIFF
--- a/packages/flutter_solidart/lib/src/models/provider_extensions.dart
+++ b/packages/flutter_solidart/lib/src/models/provider_extensions.dart
@@ -7,14 +7,7 @@ part of '../widgets/provider_scope.dart';
 /// Get the value of a provider.
 extension GetProviderExtension<T> on Provider<T> {
   /// {@macro provider-scope.get}
-  T get(BuildContext context) {
-    final provider = maybeGet(context);
-    if (provider == null) throw ProviderError<T>(this);
-    return provider;
-  }
-
-  /// {@macro provider-scope.maybeGet}
-  T? maybeGet(BuildContext context) {
+  MaybeProvidedValue<T> get(BuildContext context) {
     return ProviderScope._getOrCreateProvider(context, id: this);
   }
 }
@@ -23,14 +16,7 @@ extension GetProviderExtension<T> on Provider<T> {
 extension ObserveSignalInProviderExtension<T extends SignalBase<dynamic>>
     on Provider<T> {
   /// {@macro provider-scope.observe}
-  T observe(BuildContext context) {
-    final provider = maybeObserve(context);
-    if (provider == null) throw ProviderError<T>(this);
-    return provider;
-  }
-
-  /// {@macro provider-scope.maybeObserve}
-  T? maybeObserve(BuildContext context) {
+  MaybeProvidedValue<T> observe(BuildContext context) {
     return ProviderScope._getOrCreateProvider<T>(
       context,
       id: this,
@@ -43,12 +29,9 @@ extension ObserveSignalInProviderExtension<T extends SignalBase<dynamic>>
 extension UpdateSignalInProviderExtension<T> on Provider<Signal<T>> {
   /// {@macro provider-scope.update}
   void update(BuildContext context, T Function(T value) callback) {
-    get(context).updateValue(callback);
-  }
-
-  /// {@macro provider-scope.maybeUpdate}
-  void maybeUpdate(BuildContext context, T Function(T value) callback) {
-    maybeGet(context)?.updateValue(callback);
+    if (get(context) case ProvidedValue(value: final signal)) {
+      signal.updateValue(callback);
+    }
   }
 }
 
@@ -59,18 +42,8 @@ extension UpdateSignalInProviderExtension<T> on Provider<Signal<T>> {
 /// Get the value of a provider.
 extension GetProviderWithArgumentExtension<T, A> on ArgProvider<T, A> {
   /// {@macro provider-scope.get}
-  T get(BuildContext context) {
-    final provider = maybeGet(context);
-    if (provider == null) {
-      throw ProviderWithoutScopeError(this);
-    }
-    return provider;
-  }
-
-  /// {@macro provider-scope.maybeGet}
-  T? maybeGet(BuildContext context) {
-    if (_instance == null) return null;
-
+  MaybeProvidedValue<T> get(BuildContext context) {
+    if (_instance == null) return ProviderNotFound._();
     return ProviderScope._getOrCreateProvider(context, id: _instance!);
   }
 }
@@ -79,17 +52,8 @@ extension GetProviderWithArgumentExtension<T, A> on ArgProvider<T, A> {
 extension ObserveSignalInProviderWithArgumentExtension<
     T extends SignalBase<dynamic>, A> on ArgProvider<T, A> {
   /// {@macro provider-scope.observe}
-  T observe(BuildContext context) {
-    final provider = maybeObserve(context);
-    if (provider == null) {
-      throw ProviderWithoutScopeError(this);
-    }
-    return provider;
-  }
-
-  /// {@macro provider-scope.maybeObserve}
-  T? maybeObserve(BuildContext context) {
-    if (_instance == null) return null;
+  MaybeProvidedValue<T> observe(BuildContext context) {
+    if (_instance == null) return ProviderNotFound._();
     return ProviderScope._getOrCreateProvider<T>(
       context,
       id: _instance!,
@@ -102,15 +66,11 @@ extension ObserveSignalInProviderWithArgumentExtension<
 ///
 extension UpdateSignalInProviderWithArgumentExtension<T, A>
     on ArgProvider<Signal<T>, A> {
-  /// Update the value of a [Signal<T>] that is in this arg provider with an
-  /// argument.
-  void update(BuildContext context, T Function(T value) callback) {
-    get(context).updateValue(callback);
-  }
-
   /// Safely attempt to update the value of the [Signal<T>] that is in this arg
   /// provider with an argument.
-  void maybeUpdate(BuildContext context, T Function(T value) callback) {
-    maybeGet(context)?.updateValue(callback);
+  void update(BuildContext context, T Function(T value) callback) {
+    if (get(context) case ProvidedValue(value: final signal)) {
+      signal.updateValue(callback);
+    }
   }
 }

--- a/packages/flutter_solidart/lib/src/utils/maybe_provider.dart
+++ b/packages/flutter_solidart/lib/src/utils/maybe_provider.dart
@@ -1,0 +1,20 @@
+part of '../widgets/provider_scope.dart';
+
+sealed class MaybeProvidedValue<T> {
+  MaybeProvidedValue._();
+
+  T unwrap() => switch (this) {
+        ProvidedValue<T>(:final T value) => value,
+        ProviderNotFound<T>() => throw ProviderError(),
+      };
+}
+
+final class ProvidedValue<T> extends MaybeProvidedValue<T> {
+  ProvidedValue._(this.value) : super._();
+
+  final T value;
+}
+
+final class ProviderNotFound<T> extends MaybeProvidedValue<T> {
+  ProviderNotFound._() : super._();
+}

--- a/packages/flutter_solidart/lib/src/widgets/provider_scope_value.dart
+++ b/packages/flutter_solidart/lib/src/widgets/provider_scope_value.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/src/widgets/provider_scope.dart';
 
 class _InheritedProviderScopeValue extends InheritedWidget {
   const _InheritedProviderScopeValue({

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -317,9 +317,9 @@ void main() {
                 doubleCounterProvider,
               ],
               builder: (context, child) {
-                final counter = counterProvider.observe(context).value;
+                final counter = counterProvider.observe(context).unwrap().value;
                 final doubleCounter =
-                    doubleCounterProvider.observe(context).value;
+                    doubleCounterProvider.observe(context).unwrap().value;
                 return Text('$counter $doubleCounter');
               },
             ),

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -159,17 +159,10 @@ class Computed<T> extends ReadSignal<T> implements Derivation {
   }
 
   @override
-  T? get previousValue {
+  MaybePreviousValue<T> get previousValue {
     // cause observation
     value;
     return super.previousValue;
-  }
-
-  @override
-  bool get hasPreviousValue {
-    // cause observation
-    value;
-    return super._hasPreviousValue;
   }
 
   @override

--- a/packages/solidart/lib/src/core/devtools.dart
+++ b/packages/solidart/lib/src/core/devtools.dart
@@ -43,7 +43,7 @@ void _notifyDevToolsAboutSignal(
   var previousValue = signal._previousValue;
   if (signal is Resource) {
     value = signal._value.asReady?.value;
-    previousValue = signal._previousValue?.asReady?.value;
+    previousValue = signal._previousValue;
   }
   final jsonValue = _toJson(value);
   final jsonPreviousValue = _toJson(previousValue);
@@ -52,7 +52,6 @@ void _notifyDevToolsAboutSignal(
     'name': signal.name,
     'value': jsonValue,
     'previousValue': jsonPreviousValue,
-    'hasPreviousValue': signal._hasPreviousValue,
     'type': switch (signal) {
       Resource() => 'Resource',
       ListSignal() => 'ListSignal',
@@ -63,8 +62,7 @@ void _notifyDevToolsAboutSignal(
       ReadSignal() => 'ReadSignal',
     },
     'valueType': value.runtimeType.toString(),
-    if (signal._hasPreviousValue)
-      'previousValueType': previousValue.runtimeType.toString(),
+    'previousValueType': previousValue.runtimeType.toString(),
     'disposed': signal._disposed,
     'autoDispose': signal.autoDispose,
     'listenerCount': signal.listenerCount,

--- a/packages/solidart/lib/src/core/read_signal.dart
+++ b/packages/solidart/lib/src/core/read_signal.dart
@@ -90,10 +90,7 @@ class ReadSignal<T> extends Atom implements SignalBase<T> {
   bool _hasValue = false;
 
   // Tracks the internal previous value
-  T? _previousValue;
-
-  // Whether or not there is a previous value
-  bool _hasPreviousValue = false;
+  MaybePreviousValue<T> _previousValue = const Absent();
 
   /// All the observers
   final List<ObserveCallback<T>> _listeners = [];
@@ -163,23 +160,16 @@ class ReadSignal<T> extends Atom implements SignalBase<T> {
   @override
   T call() => value;
 
-  @override
-  bool get hasPreviousValue {
-    _reportObserved();
-    return _hasPreviousValue;
-  }
-
   /// The previous value, if any.
   @override
-  T? get previousValue {
+  MaybePreviousValue<T> get previousValue {
     _reportObserved();
     return _previousValue;
   }
 
   /// Sets the previous signal value to [value].
   void _setPreviousValue(T value) {
-    _previousValue = value;
-    _hasPreviousValue = true;
+    _previousValue = Present(value);
   }
 
   bool _disposed = false;

--- a/packages/solidart/lib/src/core/resource.dart
+++ b/packages/solidart/lib/src/core/resource.dart
@@ -199,7 +199,7 @@ class Resource<T> extends Signal<ResourceState<T>> {
 
   @Deprecated('Use previousState instead')
   @override
-  ResourceState<T>? get previousValue => previousState;
+  MaybePreviousValue<ResourceState<T>> get previousValue => previousState;
 
   @Deprecated('Use update instead')
   @override
@@ -210,9 +210,9 @@ class Resource<T> extends Signal<ResourceState<T>> {
   // coverage:ignore-end
 
   /// The previous resource state
-  ResourceState<T>? get previousState {
+  MaybePreviousValue<ResourceState<T>> get previousState {
     _resolveIfNeeded();
-    if (!_resolved) return null;
+    if (!_resolved) return Absent();
     return super.previousValue;
   }
 

--- a/packages/solidart/lib/src/core/signal_base.dart
+++ b/packages/solidart/lib/src/core/signal_base.dart
@@ -66,14 +66,10 @@ abstract class SignalBase<T> {
   /// The current signal value
   T call();
 
-  /// Indicates if there is a previous value. It is especially
-  /// helpful if [T] is nullable.
-  bool get hasPreviousValue;
-
   /// The previous signal value
   ///
   /// Defaults to null when no previous value is present.
-  T? get previousValue;
+  MaybePreviousValue<T> get previousValue;
 
   /// Tells if the signal is disposed;
   bool get disposed;

--- a/packages/solidart/lib/src/utils.dart
+++ b/packages/solidart/lib/src/utils.dart
@@ -10,7 +10,10 @@ typedef VoidCallback = void Function();
 typedef ErrorCallback = void Function(Object error);
 
 /// The callback fired by the observer
-typedef ObserveCallback<T> = void Function(T? previousValue, T value);
+typedef ObserveCallback<T> = void Function(
+  MaybePreviousValue<T> previousValue,
+  T value,
+);
 
 /// {@template solidartexception}
 /// An Exception class to capture Solidart specific exceptions
@@ -62,3 +65,23 @@ Timer Function(void Function()) createDelayedScheduler(Duration duration) =>
     (fn) => Timer(duration, fn);
 
 /// coverage:ignore-end
+
+sealed class MaybePreviousValue<T> {
+  MaybePreviousValue();
+
+  T unwrap() => switch (this) {
+        Present<T>(:final T value) => value,
+        Absent<T>() => throw UnwrapAbsentPreviousValueError(),
+      };
+}
+
+final class Present<T> extends MaybePreviousValue<T> {
+  final T value;
+  Present(this.value);
+}
+
+final class Absent<T> extends MaybePreviousValue<T> {
+  Absent();
+}
+
+final class UnwrapAbsentPreviousValueError extends Error {}

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -353,30 +353,19 @@ void main() {
         final signal = Signal(0);
         final derived = Computed(() => signal() * 2);
         await pumpEventQueue();
-        expect(derived.hasPreviousValue, false);
-        expect(derived.previousValue, null);
+        expect(derived.previousValue, Absent<int>());
 
         signal.set(1);
         await pumpEventQueue();
-        expect(derived.hasPreviousValue, true);
-        expect(derived.previousValue, 0);
+        expect(derived.previousValue, Present(0));
 
         signal.set(2);
         await pumpEventQueue();
-        expect(derived.hasPreviousValue, true);
-        expect(derived.previousValue, 2);
+        expect(derived.previousValue, Present(2));
 
         signal.set(1);
         await pumpEventQueue();
-        expect(derived.hasPreviousValue, true);
-        expect(derived.previousValue, 4);
-      });
-
-      test('signal has previous value', () {
-        final s = Signal(0);
-        expect(s.hasPreviousValue, false);
-        s.set(1);
-        expect(s.hasPreviousValue, true);
+        expect(derived.previousValue, Present(4));
       });
 
       test('nullable derived signal', () async {


### PR DESCRIPTION
This PR improves the error handling and simplifies the API.

It forces the user to consider both cases where a value is not available yet.

For signals, it treats nullable types the same as non-nullable ones: previously the value `null` was unclear and `hasPreviousValue` was necessary with nullable values. With this PR, the API really feels the same both for nullable and non-nullable types.

For providers, it forces the user to handle providers that are not found (IMO this is better than using `solidart_lint` to highlight `get`, `observe` and `update` without the `maybe` in front). Since we can't exclude the possibility of a value contained in a Provider to be null, this PR ensure the difference between the `null` value and a provider not found.

Note that, in both cases, it is possible to bypass the error handling by using `unwrap()`.

Theoretically, an `Option` (or `Maybe`) class could be defined in the `solidart` package and that class could be used instead of having both `MaybeProvidedValue` and `MaybePreviousValue`, since Dart does not really have a ubiquitous `Option` or `Maybe` type. However, I think that these two specific types might make it simpler for new users to understand.