### PR TITLE
refactor: alien_signals 0.4.3

### DIFF
--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.1.0-pre.1
+
+- **BREAKING**: Update `alien_signals` dependency from `^0.2.1` to `^0.4.3` with significant performance improvements.
+- **REFACTOR**: Replace custom reactive node implementations with `alien.ReactiveNode` for better compatibility and performance.
+- **REFACTOR**: Simplify signal, computed and effect implementations by leveraging new `alien_signals` API.
+- **PERFORMANCE**: Improve performance by removing redundant tracking operations in the reactive system.
+- **FIX**: Add proper cleanup for disposed nodes to prevent memory leaks.
+- **FIX**: Fix potential memory leaks in auto-dispose scenarios.
+- **FEAT**: Add `forceDirty` flag to `_AlienSignal` to manually trigger signal updates when needed.
+- **FIX**: Remove equality check and automatic reporting in `ReadableSignal` to fix notification issues.
+- **FIX**: Clear queued flag when running effects in `ReactiveSystem` to ensure proper effect execution.
+- **CHORE**: Reorder dev_dependencies in pubspec.yaml for improved organization and readability.
+
 ## 2.0.1
 
 - **FIX**: DevTools extension not working.

--- a/packages/solidart/lib/src/core/alien.dart
+++ b/packages/solidart/lib/src/core/alien.dart
@@ -47,9 +47,16 @@ class _AlienSignal<T> extends alien.ReactiveNode implements _AlienUpdatable {
   T previousValue;
   T value;
 
+  bool forceDirty = false;
+
   @override
   bool update() {
     flags = alien.ReactiveFlags.mutable;
+    if (forceDirty) {
+      forceDirty = false;
+      return true;
+    }
+
     return previousValue != (previousValue = value);
   }
 }

--- a/packages/solidart/lib/src/core/alien.dart
+++ b/packages/solidart/lib/src/core/alien.dart
@@ -1,123 +1,60 @@
 part of 'core.dart';
 
-abstract interface class _Effect implements alien.Dependency, alien.Subscriber {
-  void Function() get fn;
-}
+class _AlienComputed<T> extends alien.ReactiveNode implements _AlienUpdatable {
+  // flags: ReactiveFlags.mutable | ReactiveFlags.dirty
+  _AlienComputed(this.parent, this.getter)
+      : super(flags: 17 as alien.ReactiveFlags);
 
-abstract interface class _Signal<T> implements alien.Dependency {
-  abstract T currentValue;
-  T call();
-}
+  final Computed<T> parent;
+  final T Function(T? oldValue) getter;
 
-abstract interface class _WriteableSignal<T> extends _Signal<T> {
-  @override
-  T call([T value]);
-}
+  T? value;
 
-abstract interface class _Computed<T> extends _Signal<T?>
-    implements alien.Subscriber {
-  @override
-  abstract T? currentValue;
+  void dispose() => reactiveSystem.stopEffect(this);
 
   @override
-  T call();
-
-  bool notify();
+  bool update() {
+    final prevSub = reactiveSystem.setCurrentSub(this);
+    reactiveSystem.startTracking(this);
+    try {
+      final oldValue = value;
+      return oldValue != (value = getter(oldValue));
+    } finally {
+      reactiveSystem
+        ..setCurrentSub(prevSub)
+        ..endTracking(this);
+    }
+  }
 }
 
-class _AlienSignal<T> with alien.Dependency implements _WriteableSignal<T> {
-  _AlienSignal(
-    this.currentValue, {
-    required this.parent,
-  });
+class _AlienEffect extends alien.ReactiveNode {
+  _AlienEffect(this.parent, this.run)
+      : super(flags: alien.ReactiveFlags.watching);
 
-  @override
-  T currentValue;
+  final Effect parent;
+  final void Function() run;
+
+  void dispose() => reactiveSystem.stopEffect(this);
+}
+
+class _AlienSignal<T> extends alien.ReactiveNode implements _AlienUpdatable {
+  _AlienSignal(this.parent, this.value)
+      : previousValue = value,
+        super(flags: alien.ReactiveFlags.mutable);
 
   final SignalBase<dynamic> parent;
 
-  @override
-  T call([T? _]) {
-    if (reactiveSystem.activeSub != null) {
-      reactiveSystem.link(this, reactiveSystem.activeSub!);
-    }
+  T previousValue;
+  T value;
 
-    return currentValue;
+  @override
+  bool update() {
+    flags = alien.ReactiveFlags.mutable;
+    return previousValue != (previousValue = value);
   }
 }
 
-class _AlienComputed<T>
-    with alien.Dependency, alien.Subscriber
-    implements _Computed<T> {
-  _AlienComputed(this.getter, {required this.parent});
-
-  final T Function(T? oldValue) getter;
-
-  final Computed<T> parent;
-
-  @override
-  T? currentValue;
-
-  @override
-  int flags = alien.SubscriberFlags.computed | alien.SubscriberFlags.dirty;
-
-  @override
-  T call() {
-    if ((flags &
-            (alien.SubscriberFlags.dirty |
-                alien.SubscriberFlags.pendingComputed)) !=
-        0) {
-      reactiveSystem.processComputedUpdate(this, flags);
-    }
-    if (reactiveSystem.activeSub != null) {
-      reactiveSystem.link(this, reactiveSystem.activeSub!);
-    } else if (reactiveSystem.activeScope != null) {
-      reactiveSystem.link(this, reactiveSystem.activeScope!);
-    }
-
-    return currentValue as T;
-  }
-
-  @override
-  bool notify() {
-    final oldValue = currentValue;
-    final newValue = getter(oldValue);
-    if (!parent._compare(oldValue, newValue)) {
-      currentValue = newValue;
-      return true;
-    }
-    return false;
-  }
-
-  void dispose() {
-    reactiveSystem.disposeSub(this);
-  }
-}
-
-class _AlienEffect with alien.Dependency, alien.Subscriber implements _Effect {
-  _AlienEffect(
-    this.fn, {
-    required this.parent,
-  });
-
-  @override
-  final void Function() fn;
-
-  final Effect parent;
-
-  @override
-  int flags = alien.SubscriberFlags.effect;
-
-  void dispose() {
-    reactiveSystem.disposeSub(this);
-  }
-
-  void run() {
-    if (reactiveSystem.activeSub != null) {
-      reactiveSystem.link(this, reactiveSystem.activeSub!);
-    } else if (reactiveSystem.activeScope != null) {
-      reactiveSystem.link(this, reactiveSystem.activeScope!);
-    }
-    reactiveSystem.runEffect(this);
-  }
+// ignore: one_member_abstracts
+abstract interface class _AlienUpdatable {
+  bool update();
 }

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -95,6 +95,7 @@ class Computed<T> extends ReadSignal<T> {
   }) {
     var runnedOnce = false;
     _internalComputed = _AlienComputed(
+      this,
       (previousValue) {
         if (trackPreviousValue && previousValue is T) {
           _hasPreviousValue = true;
@@ -114,7 +115,6 @@ class Computed<T> extends ReadSignal<T> {
           throw SolidartCaughtException(e, stackTrace: s);
         }
       },
-      parent: this,
     );
 
     _notifySignalCreation();
@@ -144,7 +144,7 @@ class Computed<T> extends ReadSignal<T> {
   @override
   bool get hasValue => true;
 
-  final _deps = <alien.Dependency>{};
+  final _deps = <alien.ReactiveNode>{};
 
   @override
   void dispose() {
@@ -168,15 +168,16 @@ class Computed<T> extends ReadSignal<T> {
   @override
   T get value {
     if (_disposed) {
-      reactiveSystem.pauseTracking();
-      final value = _internalComputed();
-      reactiveSystem.resumeTracking();
-      return value;
+      return untracked(
+        () => reactiveSystem.getComputedValue(_internalComputed),
+      );
     }
-    final value = _internalComputed();
+
+    final value = reactiveSystem.getComputedValue(_internalComputed);
     if (autoDispose) {
       Future.microtask(_mayDispose);
     }
+
     return value;
   }
 

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -244,6 +244,7 @@ class Computed<T> extends ReadSignal<T> {
 
   /// Indicates if the [oldValue] and the [newValue] are equal
   @override
+  // ignore: unused_element
   bool _compare(T? oldValue, T? newValue) {
     // skip if the value are equals
     if (equals) {

--- a/packages/solidart/lib/src/core/core.dart
+++ b/packages/solidart/lib/src/core/core.dart
@@ -5,6 +5,9 @@ import 'dart:developer' as dev;
 import 'dart:math';
 
 import 'package:alien_signals/alien_signals.dart' as alien;
+// ignore: implementation_imports
+import 'package:alien_signals/src/preset.dart' as alien show EffectFlags;
+
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:solidart/src/utils.dart';

--- a/packages/solidart/lib/src/core/reactive_system.dart
+++ b/packages/solidart/lib/src/core/reactive_system.dart
@@ -172,7 +172,7 @@ class ReactiveSystem extends alien.ReactiveSystem {
       while (notifyIndex < queuedEffectsLength) {
         final effect = queuedEffects[notifyIndex];
         queuedEffects[notifyIndex++] = null;
-        run(effect!, effect.flags);
+        run(effect!, effect.flags &= -65 /* ~EffectFlags.queued */);
       }
     } finally {
       notifyIndex = queuedEffectsLength = 0;

--- a/packages/solidart/lib/src/core/reactive_system.dart
+++ b/packages/solidart/lib/src/core/reactive_system.dart
@@ -25,75 +25,157 @@ class ReactiveName {
 @protected
 final reactiveSystem = ReactiveSystem();
 
-class ReactiveSystem extends alien.ReactiveSystem<_Computed<dynamic>> {
-  alien.Subscriber? activeSub;
-  alien.Subscriber? activeScope;
+class ReactiveSystem extends alien.ReactiveSystem {
+  final queuedEffects = <int, alien.ReactiveNode?>{};
+  final pauseStack = <alien.ReactiveNode>[];
+
   int batchDepth = 0;
-  final pauseStack = <alien.Subscriber?>[];
+  int notifyIndex = 0;
+  int queuedEffectsLength = 0;
+  alien.ReactiveNode? activeSub;
 
   @override
-  bool notifyEffect(alien.Subscriber effect) {
-    final flags = effect.flags;
-    if ((flags & alien.SubscriberFlags.dirty) != 0 ||
-        ((flags & alien.SubscriberFlags.pendingComputed) != 0 &&
-            updateDirtyFlag(effect, flags))) {
-      (effect as _AlienEffect).run();
-    } else {
-      processPendingInnerEffects(effect, effect.flags);
-    }
-    return true;
-  }
-
-  @override
-  bool updateComputed(_Computed<dynamic> computed) {
-    final prevSub = activeSub;
-    activeSub = computed;
-    startTracking(computed);
-    try {
-      return computed.notify();
-    } finally {
-      activeSub = prevSub;
-      endTracking(computed);
+  void notify(alien.ReactiveNode node) {
+    final flags = node.flags;
+    if ((flags & alien.EffectFlags.queued) == 0) {
+      node.flags = flags | alien.EffectFlags.queued;
+      final subs = node.subs;
+      if (subs != null) {
+        notify(subs.sub);
+      } else {
+        queuedEffects[queuedEffectsLength++] = node;
+      }
     }
   }
 
-  void startBatch() {
-    ++batchDepth;
+  @override
+  void unwatched(alien.ReactiveNode node) {
+    if (node is _AlienComputed) {
+      var toRemove = node.deps;
+      if (toRemove != null) {
+        // ReactiveFlags.mutable | ReactiveFlags.dirty
+        node.flags = 17 as alien.ReactiveFlags;
+        do {
+          toRemove = unlink(toRemove!, node);
+        } while (toRemove != null);
+      }
+    } else if (node is! _AlienSignal) {
+      stopEffect(node);
+    }
   }
 
+  @override
+  bool update(alien.ReactiveNode node) {
+    assert(
+      node is _AlienUpdatable,
+      'Reactive node type must be signal or computed',
+    );
+    return (node as _AlienUpdatable).update();
+  }
+
+  void startBatch() => ++batchDepth;
   void endBatch() {
-    if ((--batchDepth) == 0) {
-      processEffectNotifications();
-    }
+    if ((--batchDepth) == 0) flush();
   }
 
-  void disposeSub(alien.Subscriber sub) {
-    startTracking(sub);
-    endTracking(sub);
-  }
-
-  void runEffect(_Effect effect) {
+  alien.ReactiveNode? setCurrentSub(alien.ReactiveNode? sub) {
     final prevSub = activeSub;
-    activeSub = effect;
-    startTracking(effect);
-    try {
-      effect.fn();
-    } finally {
-      activeSub = prevSub;
-      endTracking(effect);
+    activeSub = sub;
+    return prevSub;
+  }
+
+  T getComputedValue<T>(_AlienComputed<T> computed) {
+    final flags = computed.flags;
+    if ((flags & alien.ReactiveFlags.dirty) != 0 ||
+        ((flags & alien.ReactiveFlags.pending) != 0 &&
+            checkDirty(computed.deps!, computed))) {
+      if (computed.update()) {
+        final subs = computed.subs;
+        if (subs != null) shallowPropagate(subs);
+      }
+    } else if ((flags & alien.ReactiveFlags.pending) != 0) {
+      computed.flags = flags & -33 /* ~ReactiveFlags.pending */;
+    }
+    if (activeSub != null) {
+      link(computed, activeSub!);
+    }
+
+    return computed.value as T;
+  }
+
+  T getSignalValue<T>(_AlienSignal<T> signal) {
+    final value = signal.value;
+    if ((signal.flags & alien.ReactiveFlags.dirty) != 0) {
+      if (signal.update()) {
+        final subs = signal.subs;
+        if (subs != null) shallowPropagate(subs);
+      }
+    }
+
+    if (activeSub != null) link(signal, activeSub!);
+    return value;
+  }
+
+  void setSignalValue<T>(_AlienSignal<T> signal, T value) {
+    if (signal.value != (signal.value = value)) {
+      signal.flags = 17
+          as alien.ReactiveFlags; // ReactiveFlags.mutable | ReactiveFlags.dirty
+      final subs = signal.subs;
+      if (subs != null) {
+        propagate(subs);
+        if (batchDepth == 0) flush();
+      }
     }
   }
 
-  void pauseTracking() {
-    pauseStack.add(activeSub);
-    activeSub = null;
+  void stopEffect(alien.ReactiveNode effect) {
+    assert(effect is! _AlienSignal, 'Reactive node type not matched');
+    var dep = effect.deps;
+    while (dep != null) {
+      dep = unlink(dep, effect);
+    }
+
+    final sub = effect.subs;
+    if (sub != null) unlink(sub, effect);
+    effect.flags = alien.ReactiveFlags.none;
   }
 
-  void resumeTracking() {
+  void run(alien.ReactiveNode effect, alien.ReactiveFlags flags) {
+    if ((flags & alien.ReactiveFlags.dirty) != 0 ||
+        ((flags & alien.ReactiveFlags.pending) != 0 &&
+            checkDirty(effect.deps!, effect))) {
+      final prevSub = setCurrentSub(effect);
+      startTracking(effect);
+      try {
+        (effect as _AlienEffect).run();
+      } finally {
+        activeSub = prevSub;
+        endTracking(effect);
+      }
+      return;
+    } else if ((flags & alien.ReactiveFlags.pending) != 0) {
+      effect.flags = flags & -33 /* ~ReactiveFlags.pending */;
+    }
+    var link = effect.deps;
+    while (link != null) {
+      final dep = link.dep;
+      final depFlags = dep.flags;
+      if ((depFlags & alien.EffectFlags.queued) != 0) {
+        run(dep, dep.flags = depFlags & -65 /* ~EffectFlags.queued */);
+      }
+      link = link.nextDep;
+    }
+  }
+
+  void flush() {
     try {
-      activeSub = pauseStack.removeLast();
-    } catch (_) {
-      activeSub = null;
+      while (notifyIndex < queuedEffectsLength) {
+        final effect = queuedEffects[notifyIndex];
+        queuedEffects[notifyIndex++] = null;
+        run(effect!, effect.flags);
+      }
+    } finally {
+      notifyIndex = queuedEffectsLength = 0;
     }
   }
 }

--- a/packages/solidart/lib/src/core/read_signal.dart
+++ b/packages/solidart/lib/src/core/read_signal.dart
@@ -169,7 +169,6 @@ class ReadableSignal<T> implements ReadSignal<T> {
     _untrackedPreviousValue = _untrackedValue;
     _untrackedValue = newValue;
     reactiveSystem.setSignalValue(_internalSignal, Some(newValue));
-    _reportChanged();
   }
 
   @override
@@ -338,7 +337,17 @@ class ReadableSignal<T> implements ReadSignal<T> {
     }
   }
 
+  /// Forces a change notification even when the value
+  /// hasn't substantially changed.
+  ///
+  /// This should only be used when you need to force
+  /// trigger reactions despite no
+  /// actual value change. For normal value updates,
+  // ignore: comment_references
+  /// use [reactiveSystem.setSignalValue] instead.
   void _reportChanged() {
+    _internalSignal.forceDirty = true;
+    _internalSignal.flags = 17 as alien.ReactiveFlags;
     final subs = _internalSignal.subs;
     if (subs != null) {
       reactiveSystem.propagate(subs);

--- a/packages/solidart/lib/src/core/untracked.dart
+++ b/packages/solidart/lib/src/core/untracked.dart
@@ -4,11 +4,11 @@ part of 'core.dart';
 ///
 /// This can be useful inside Effects or Observations to prevent a signal from
 /// being tracked.
-T untracked<T>(T Function() fn) {
+T untracked<T>(T Function() callback) {
+  final prevSub = reactiveSystem.setCurrentSub(null);
   try {
-    reactiveSystem.pauseTracking();
-    return fn();
+    return callback();
   } finally {
-    reactiveSystem.resumeTracking();
+    reactiveSystem.setCurrentSub(prevSub);
   }
 }

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -14,7 +14,7 @@ resolution: workspace
 
 dependencies:
   # we depend on the alien signals reactivity implementation because it's the fastest available right now (30/12/2024)
-  alien_signals: ^0.2.1
+  alien_signals: ^0.4.3
   collection: ^1.18.0
   meta: ^1.11.0
 

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 2.0.1
+version: 2.1.0-pre.1
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,9 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.6.0
-dev_dependencies:
-  melos: ^3.4.0
-  reactivity_benchmark: ^0.0.1
+
 workspace:
   - packages/flutter_solidart
   - packages/flutter_solidart/example
@@ -16,3 +14,7 @@ workspace:
   - examples/github_search
   - examples/todos
   - examples/toggle_theme
+
+dev_dependencies:
+  melos: ^3.4.0
+  reactivity_benchmark: ^0.0.1


### PR DESCRIPTION
- **BREAKING**: Update `alien_signals` dependency from `^0.2.1` to `^0.4.3` with significant performance improvements.
- **REFACTOR**: Replace custom reactive node implementations with `alien.ReactiveNode` for better compatibility and performance.
- **REFACTOR**: Simplify signal, computed and effect implementations by leveraging new `alien_signals` API.
- **PERFORMANCE**: Improve performance by removing redundant tracking operations in the reactive system.
- **FIX**: Add proper cleanup for disposed nodes to prevent memory leaks.
- **FIX**: Fix potential memory leaks in auto-dispose scenarios.
- **FEAT**: Add `forceDirty` flag to `_AlienSignal` to manually trigger signal updates when needed.
- **FIX**: Remove equality check and automatic reporting in `ReadableSignal` to fix notification issues.
- **FIX**: Clear queued flag when running effects in `ReactiveSystem` to ensure proper effect execution.
- **CHORE**: Reorder dev_dependencies in pubspec.yaml for improved organization and readability.