### PR TITLE
feat: detach effects

### DIFF
--- a/packages/flutter_solidart/lib/src/widgets/signal_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/signal_builder.dart
@@ -160,6 +160,9 @@ class SignalBuilderElement extends ComponentElement {
 
   @override
   Widget build() {
+    final prevDetachEffects = SolidartConfig.detachEffects;
+    SolidartConfig.detachEffects = true;
+
     final prevSub = reactiveSystem.activeSub;
     // ignore: invalid_use_of_protected_member
     reactiveSystem.activeSub = _effect?.subscriber;
@@ -168,6 +171,7 @@ class SignalBuilderElement extends ComponentElement {
       return _widget.build(_parent!);
     } finally {
       reactiveSystem.activeSub = prevSub;
+      SolidartConfig.detachEffects = prevDetachEffects;
     }
   }
 }

--- a/packages/solidart/lib/src/core/config.dart
+++ b/packages/solidart/lib/src/core/config.dart
@@ -23,6 +23,16 @@ abstract class SolidartConfig {
 
   /// The list of observers.
   static final observers = <SolidartObserver>[];
+
+  /// Detach effects
+  ///
+  /// By default, false, nested effects are controlled by the
+  /// behavior of the parent effect.
+  ///
+  /// If you want nested inner effects to have their own independent behavior,
+  /// you can set this to true so that the Reactive system creates a dependency
+  /// chain for nested inner effects.
+  static bool detachEffects = false;
 }
 
 /// {@template solidart-observer}

--- a/packages/solidart/lib/src/core/effect.dart
+++ b/packages/solidart/lib/src/core/effect.dart
@@ -168,7 +168,7 @@ class Effect implements ReactionInterface {
   bool get disposed => _disposed;
 
   void _schedule() {
-    if (reactiveSystem.activeSub != null) {
+    if (!SolidartConfig.detachEffects && reactiveSystem.activeSub != null) {
       reactiveSystem.link(_internalEffect, reactiveSystem.activeSub!);
     }
     final prevSub = reactiveSystem.setCurrentSub(_internalEffect);


### PR DESCRIPTION
resolve #118

By default, false, nested effects are controlled by the behavior of the parent effect.

If you want nested inner effects to have their own independent behavior, you can set this to true so that the Reactive system creates a dependency chain for nested inner effects.