### PR TITLE
refactor signal builder

### DIFF
--- a/docs-v2/src/content/docs/flutter/signal_builder.mdx
+++ b/docs-v2/src/content/docs/flutter/signal_builder.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 1
 ---
 
+import { Aside } from '@astrojs/starlight/components';
+
 A magic widget builder that automatically rebuilds everytime a signal used inside its builder changes.
 
 Reacts to any number of *signals* calling the `builder` each time.
@@ -36,3 +38,9 @@ class _SampleCounterState extends State<SampleCounter> {
 }
 ```
 
+<Aside type="caution">
+By default, if no __active__ signals are detected inside the builder method, an assertion error will be thrown in debug mode.
+This is to help catch mistakes where you might have forgotten to use an __active__ signal inside the builder.
+
+There may be cases where you want to disable this behavior, for example if you want it to build with the latest value of a disposed signal, in that case you can use `SolidartConfig.assertSignalBuilderWithoutDependencies = false` before `runApp`.
+</Aside>

--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.5.0
+
+- **REFACTOR**: Improve and simplify the `SignalBuilder` implementation (thanks to @medz).
+- **FEAT**: Add `assertSignalBuilderWithoutDependencies` to `SolidartConfig` to manually disable the assertion thrown when a `SignalBuilder` doesn't track any reactive value. (By default it's true, so it will raise an assertion).
+
+### Changes from solidart
+
+- **REFACTOR**: Make auto disposal synchronous.
+
 ## 2.4.1
 
 - **FIX**: `SignalBuilder` not working with inherited widgets. This is just a temporary patch, a better solution needs to be found, because inherited widgets tracked inside the builder won't react.

--- a/packages/flutter_solidart/lib/src/widgets/signal_builder.dart
+++ b/packages/flutter_solidart/lib/src/widgets/signal_builder.dart
@@ -1,32 +1,8 @@
 // ignore_for_file: document_ignores
 
-import 'dart:async';
-import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
 import 'package:solidart/solidart.dart';
-
-/// {@template SignalBuilderWithoutDependenciesError}
-/// This exception would be fired when an effect is created without tracking
-/// any dependencies.
-/// {@endtemplate}
-class SignalBuilderWithoutDependenciesError extends Error {
-  @override
-  String toString() => '''
-SignalBuilderWithoutDependenciesError: SignalBuilder was created without tracking any dependencies.
-Make sure to access at least one reactive value (Signal, Computed, etc.) inside the builder callback.
-This might happen if inside your `SignalBuilder.builder` method you are returning a `Builder` widget which won't track reactive values because it is considered a different function because it requires another `builder` function.
-Or if the signals are disposed (if autoDispose is enabled, which is true by default).
-      ''';
-}
-
-/// The [SignalBuilder] function used to build the widget tracking the signals.
-typedef SignalBuilderFn = Widget Function(
-  BuildContext context,
-  Widget? child,
-);
-
-/// A callback that is called when an error occurs.
-typedef SignalBuilderOnError = void Function(Object error);
 
 /// {@template signalbuilder}
 /// Reacts to the signals automatically found in the [builder] function.
@@ -54,13 +30,9 @@ typedef SignalBuilderOnError = void Function(Object error);
 /// }
 /// ```
 /// {@endtemplate}
-class SignalBuilder extends Widget {
-  /// {@macro signalbuilder}
-  const SignalBuilder({
-    super.key,
-    required this.builder,
-    this.child,
-  });
+class SignalBuilder extends StatelessWidget {
+  /// {@macro signal-builder-element}
+  const SignalBuilder({super.key, required this.builder, this.child});
 
   /// {@template signalbuilder.builder}
   /// A [SignalBuilder] which builds a widget depending on the
@@ -68,7 +40,7 @@ class SignalBuilder extends Widget {
   ///
   /// Must not be null.
   /// {@endtemplate}
-  final SignalBuilderFn builder;
+  final Widget Function(BuildContext context, Widget? child) builder;
 
   /// {@template signalbuilder.child}
   /// A signal-independent widget which is passed back to the [builder].
@@ -80,118 +52,49 @@ class SignalBuilder extends Widget {
   /// {@endtemplate}
   final Widget? child;
 
-  /// The widget that the [builder] builds.
-  @protected
+  @override
   Widget build(BuildContext context) => builder(context, child);
 
-  /// Creates the [SignalBuilderElement] element.
   @override
-  SignalBuilderElement createElement() => SignalBuilderElement(this);
+  @internal
+  StatelessElement createElement() => _SignalBuilderElement(this);
 }
 
-/// {@template signal-builder-element}
-/// The [SignalBuilder] widget's [Element] subclass.
-///
-/// Automatically tracks and reacts to the signals found in the
-/// [SignalBuilder.builder] function
-///
-/// This class is not meant to be used directly.
-/// Use [SignalBuilder] instead.
-/// {@endtemplate}
-class SignalBuilderElement extends ComponentElement {
-  /// {@macro signal-builder-element}
-  SignalBuilderElement(SignalBuilder super.widget);
+class _SignalBuilderElement extends StatelessElement {
+  _SignalBuilderElement(SignalBuilder super.widget);
 
-  Element? _parent;
-  Effect? _effect;
+  late final effect =
+      Effect(scheduler, detach: true, autoDispose: false, autorun: false);
 
-  SignalBuilder get _widget => widget as SignalBuilder;
-  Widget? _builtWidget;
-  Object? _error;
-  bool _firstBuild = true;
-
-  @override
-  void mount(Element? parent, Object? newSlot) {
-    _parent = parent;
-    _effect = Effect(
-      _invalidate,
-      autoDispose: false,
-      onError: (error) {
-        final effectiveError = switch (error) {
-          EffectWithoutDependenciesError() =>
-            SignalBuilderWithoutDependenciesError(),
-          _ => error,
-        };
-        _error = effectiveError;
-      },
-      detach: true,
-      autorun: false,
-    );
-    // mounting intentionally after effect is initialized and widget is built
-    super.mount(parent, newSlot);
-  }
-
-  // coverage:ignore-start
-  @override
-  void update(SignalBuilder newWidget) {
-    super.update(newWidget);
-    _effect?.run();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_firstBuild) return;
-    _effect?.run();
-  }
-  // coverage:ignore-end
-
-  @override
-  void unmount() {
-    _effect?.dispose();
-    _effect = null;
-    super.unmount();
-  }
-
-  // coverage:ignore-start
-  Future<void> _invalidate() async {
-    try {
-      _builtWidget = _widget.build(_parent!);
-      // ignore: avoid_catches_without_on_clauses
-    } catch (error) {
-      _error = error;
-    }
-
-    if (_shouldWaitScheduler) {
-      await SchedulerBinding.instance.endOfFrame;
-      // If the effect is disposed after this frame, avoid rebuilding
-      if (_effect!.disposed) return;
-    }
+  void scheduler() {
+    if (dirty) return;
     markNeedsBuild();
   }
 
-  bool get _shouldWaitScheduler {
-    final schedulerPhase = SchedulerBinding.instance.schedulerPhase;
-    return schedulerPhase != SchedulerPhase.idle &&
-        schedulerPhase != SchedulerPhase.postFrameCallbacks;
+  @override
+  void unmount() {
+    effect.dispose();
+    super.unmount();
   }
-  // coverage:ignore-end
 
   @override
   Widget build() {
     final prevSub = reactiveSystem.activeSub;
     // ignore: invalid_use_of_protected_member
-    reactiveSystem.activeSub = _effect?.subscriber;
+    final node = reactiveSystem.activeSub = effect.subscriber;
 
-    if (_firstBuild) {
-      _firstBuild = false;
-      _effect?.run();
-    }
-
-    // ignore: only_throw_errors
-    if (_error != null) throw _error!;
     try {
-      return _builtWidget!;
+      final built = super.build();
+      if (SolidartConfig.assertSignalBuilderWithoutDependencies) {
+        assert(
+          node.deps != null,
+          'SignalBuilder must detect at least one Signal/Computed/Resource during build.',
+        );
+      }
+      // ignore: invalid_use_of_internal_member
+      effect.setDependencies(node);
+
+      return built;
     } finally {
       reactiveSystem.activeSub = prevSub;
     }

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.11.0
-  solidart: ^2.5.0
+  solidart: ^2.6.0
 
 dev_dependencies:
   disco: ^1.0.0

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 2.4.1
+version: 2.5.0
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -897,7 +897,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       tester.takeException(),
-      const TypeMatcher<SignalBuilderWithoutDependenciesError>(),
+      isAssertionError.having(
+        (error) => error.message,
+        'SignalBuilder must detect at least one Signal/Computed during build.',
+        contains('SignalBuilder must detect at least one Signal/Computed'),
+      ),
     );
   });
 }

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.0
+
+- **REFACTOR**: Make auto disposal synchronous.
+
 ## 2.5.0
 
 - **FEAT**: Add `run` method to `Computed` to manually trigger an update of its value.

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -153,7 +153,7 @@ class Computed<T> extends ReadSignal<T> {
 
     final value = reactiveSystem.getComputedValue(_internalComputed);
     if (autoDispose) {
-      Future.microtask(_mayDispose);
+      _mayDispose();
     }
 
     return value;

--- a/packages/solidart/lib/src/core/config.dart
+++ b/packages/solidart/lib/src/core/config.dart
@@ -21,6 +21,19 @@ abstract class SolidartConfig {
   /// {@macro Resource.useRefreshing}
   static bool useRefreshing = true;
 
+  // coverage:ignore-start
+  /// Whether to assert that SignalBuilder has at least one dependency during
+  /// its build. Defaults to true.
+  ///
+  /// If you set this to false, you must ensure that the SignalBuilder has at
+  /// least one dependency, otherwise it won't rebuild when the signals change.
+  ///
+  /// The ability to disable this assertion is provided for advanced use cases
+  /// where you might have a SignalBuilder that builds something based on
+  /// disposed signals where you might be interested in their latest values.
+  static bool assertSignalBuilderWithoutDependencies = true;
+  // coverage:ignore-end
+
   /// The list of observers.
   static final observers = <SolidartObserver>[];
 

--- a/packages/solidart/lib/src/core/effect.dart
+++ b/packages/solidart/lib/src/core/effect.dart
@@ -1,23 +1,5 @@
 part of 'core.dart';
 
-/// {@template EffectWithoutDependenciesError}
-/// This exception would be fired when an effect is created without tracking
-/// any dependencies.
-/// {@endtemplate}
-class EffectWithoutDependenciesError extends Error {
-  /// {@macro EffectWithoutDependenciesException}
-  EffectWithoutDependenciesError({required this.name});
-
-  /// The name of the effect
-  final String name;
-
-  // coverage:ignore-start
-  @override
-  String toString() =>
-      '''EffectWithoutDependenciesException: Effect ($name) was created without tracking any dependencies. Make sure to access at least one active reactive value (Signal, Computed, etc.) inside the effect callback.''';
-  // coverage:ignore-end
-}
-
 /// Dispose function
 typedef DisposeEffect = void Function();
 

--- a/packages/solidart/lib/src/core/reactive_system.dart
+++ b/packages/solidart/lib/src/core/reactive_system.dart
@@ -4,6 +4,29 @@
 // Reactive flags map: https://github.com/medz/alien-signals-dart/blob/main/flags.md
 part of 'core.dart';
 
+extension MayDisposeDependencies on alien.ReactiveNode {
+  List<alien.ReactiveNode> getDependencies() {
+    final deps = <alien.ReactiveNode>[];
+    var link = this.deps;
+    for (; link != null; link = link.nextDep) {
+      deps.add(link.dep);
+    }
+    return deps;
+  }
+
+  void mayDisposeDependencies([Iterable<alien.ReactiveNode>? include]) {
+    final dependencies =
+        Set<alien.ReactiveNode>.from(getDependencies()..addAll(include ?? []));
+    for (final dep in dependencies) {
+      return switch (dep) {
+        _AlienSignal() => dep.parent._mayDispose(),
+        _AlienComputed() => dep.parent._mayDispose(),
+        _ => null,
+      };
+    }
+  }
+}
+
 typedef ReactionErrorHandler = void Function(
   Object error,
   ReactionInterface reaction,

--- a/packages/solidart/lib/src/core/reactive_system.dart
+++ b/packages/solidart/lib/src/core/reactive_system.dart
@@ -18,11 +18,12 @@ extension MayDisposeDependencies on alien.ReactiveNode {
     final dependencies =
         Set<alien.ReactiveNode>.from(getDependencies()..addAll(include ?? []));
     for (final dep in dependencies) {
-      return switch (dep) {
-        _AlienSignal() => dep.parent._mayDispose(),
-        _AlienComputed() => dep.parent._mayDispose(),
-        _ => null,
-      };
+      switch (dep) {
+        case _AlienSignal():
+          dep.parent._mayDispose();
+        case _AlienComputed():
+          dep.parent._mayDispose();
+      }
     }
   }
 }

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 2.5.0
+version: 2.6.0
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -449,21 +449,6 @@ void main() {
         );
         expect(detectedError, isA<SolidartCaughtException>());
       });
-
-      test('Effect without dependencies throws and is caught in onError',
-          () async {
-        Object? detectedError;
-        Effect(
-          () {
-            // No dependencies accessed here
-          },
-          onError: (error) {
-            detectedError = error;
-          },
-        );
-        await pumpEventQueue();
-        expect(detectedError, isA<EffectWithoutDependenciesError>());
-      });
     },
     timeout: const Timeout(Duration(seconds: 1)),
   );


### PR DESCRIPTION
closes #138 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a SolidartConfig flag to optionally disable the debug assertion when a SignalBuilder has no tracked dependencies.

- Refactor
  - Simplified SignalBuilder public surface and behavior.
  - Replaced custom no-dependencies error with a debug-time assertion.
  - Made auto-disposal synchronous for more predictable cleanup.

- Documentation
  - Added a caution explaining the SignalBuilder dependency assertion and how to disable it.

- Tests
  - Updated tests to expect assertions and removed obsolete error-based tests.

- Chores
  - Version bumps: flutter_solidart 2.5.0, solidart 2.6.0; changelogs updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->