### PR TITLE
fix computed autodisposes

### DIFF
--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1
+
+- **FIX**: Fix auto disposal of `Computed` which happened even if `autoDispose` was set to false.
+
 ## 2.6.0
 
 - **REFACTOR**: Make auto disposal synchronous.

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -187,7 +187,7 @@ class Computed<T> extends ReadSignal<T> {
 
   @override
   void _mayDispose() {
-    if (_disposed) return;
+    if (_disposed || !autoDispose) return;
     if (_internalComputed.deps == null && _internalComputed.subs == null) {
       dispose();
     } else {

--- a/packages/solidart/lib/src/core/reactive_system.dart
+++ b/packages/solidart/lib/src/core/reactive_system.dart
@@ -5,11 +5,13 @@
 part of 'core.dart';
 
 extension MayDisposeDependencies on alien.ReactiveNode {
-  Iterable<alien.ReactiveNode> getDependencies() sync* {
+  Iterable<alien.ReactiveNode> getDependencies() {
     var link = deps;
+    final foundDeps = <alien.ReactiveNode>{};
     for (; link != null; link = link.nextDep) {
-      yield link.dep;
+      foundDeps.add(link.dep);
     }
+    return foundDeps;
   }
 
   void mayDisposeDependencies([Iterable<alien.ReactiveNode>? include]) {
@@ -109,6 +111,7 @@ class ReactiveSystem extends alien.ReactiveSystem {
     final flags = computed.flags;
     if ((flags & 16 /* Dirty */) != 0 ||
         ((flags & 32 /* Pending */) != 0 &&
+            computed.deps != null &&
             checkDirty(computed.deps!, computed))) {
       if (computed.update()) {
         final subs = computed.subs;

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 2.6.0
+version: 2.6.1
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:
@@ -14,7 +14,7 @@ resolution: workspace
 
 dependencies:
   # we depend on the alien signals reactivity implementation because it's the fastest available right now (30/12/2024)
-  alien_signals: ^0.5.1
+  alien_signals: ^0.5.3
   collection: ^1.18.0
   meta: ^1.11.0
 

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -396,6 +396,33 @@ void main() {
         count.value = 2;
         expect(doubleCount.value, 2);
       });
+
+      test('Check Signal autoDisposes if no longer used', () {
+        final count = Signal(0, autoDispose: true);
+        final effect = Effect(() => count.value);
+
+        expect(count.disposed, false);
+        expect(effect.disposed, false);
+
+        effect.dispose();
+        expect(effect.disposed, true);
+        expect(count.disposed, true);
+      });
+    
+    test('Check Signal do not autoDisposes if no longer used', () {
+        final count = Signal(0, autoDispose: false);
+        final effect = Effect(() => count.value);
+
+        expect(count.disposed, false);
+        expect(effect.disposed, false);
+
+        effect.dispose();
+        expect(effect.disposed, true);
+        expect(count.disposed, false);
+
+        count.value = 1;
+        expect(count.value, 1);
+      });
     },
     timeout: const Timeout(Duration(seconds: 1)),
   );
@@ -620,6 +647,49 @@ void main() {
         doubleCount.run();
         // 3 times in total, 1 automatically and 2 manually
         verify(cb()).called(3);
+      });
+
+      test('Check Computed autoDisposes if no longer used', () {
+        final count = Signal(0);
+        final doubleCount = Computed(() => count.value * 2, autoDispose: true);
+
+        expect(count.disposed, false);
+        expect(doubleCount.disposed, false);
+
+        count.value = 1;
+        expect(count.value, 1);
+        expect(doubleCount.value, 2);
+
+        count.dispose();
+        expect(count.disposed, true);
+        // After disposing, the Computed should be disposed
+        expect(doubleCount.disposed, true);
+
+        // Changing the source signal should not trigger the Computed anymore
+        count.value = 2;
+        expect(doubleCount.value, 2);
+      });
+
+      test('Check Computed do not autoDisposes if no longer used', () {
+        final count = Signal(0);
+        final doubleCount = Computed(() => count.value * 2, autoDispose: false);
+
+        expect(count.disposed, false);
+        expect(doubleCount.disposed, false);
+
+        count.value = 1;
+        expect(count.value, 1);
+        expect(doubleCount.value, 2);
+
+        count.dispose();
+        expect(count.disposed, true);
+        // After disposing, the Computed should NOT be disposed
+        expect(doubleCount.disposed, false);
+
+        // Changing the source signal should not trigger the Computed anymore
+        // because the count signal is disposed
+        count.value = 2;
+        expect(doubleCount.value, 2);
       });
     },
     timeout: const Timeout(Duration(seconds: 1)),


### PR DESCRIPTION
Computed autodisposed even if autoDispose was set to false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Version
  - Release 2.6.1
- Bug Fixes
  - Corrected auto-disposal behavior so Computed is not disposed when autoDispose is disabled.
  - Improved safety around dependency checks to avoid null-related issues.
- Tests
  - Added comprehensive tests covering autoDispose behavior for Signals and Computeds.
- Documentation
  - Updated changelog with 2.6.1 entry.
- Chores
  - Bumped package version to 2.6.1 and updated a dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->