### PR TITLE
[solidart_lint] chore: update analyzer dependency range in pubspec.yaml

### DIFF
--- a/packages/solidart_lint/pubspec.yaml
+++ b/packages/solidart_lint/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^7.5.0
+  analyzer: ">=7.5.0 <9.0.0"
   analyzer_plugin: ^0.13.4
   collection: ^1.19.1
   custom_lint_builder: ^0.8.0


### PR DESCRIPTION
Fixes #153 

I just changed the version range for analyzer package in solidart_lint's `pubspec.yaml`.
It's not a real migration to analyer 8.0.0 but it's enough to use solidart_lint with packages that require analyzer >= 8.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analyzer dependency version constraint in the linting package configuration to support a broader range of compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->