### PR TITLE
fix: prevent LateInitializationError when accessing untracked val

### DIFF
--- a/examples/todos/lib/widgets/todos_list.dart
+++ b/examples/todos/lib/widgets/todos_list.dart
@@ -43,7 +43,7 @@ class _TodoListState extends State<TodoList> {
         final todos = mapFilterToTodosList(activeFilter).value;
         return ListView.builder(
           itemCount: todos.length,
-          itemBuilder: (BuildContext context, int index) {
+          itemBuilder: (context, index) {
             final todo = todos[index];
             return TodoItem(
               todo: todo,

--- a/examples/todos/test/widget_test.dart
+++ b/examples/todos/test/widget_test.dart
@@ -29,7 +29,7 @@ Widget wrapWithMockedTodosController({
 }
 
 void main() {
-  testWidgets('Todos with initial value', (WidgetTester tester) async {
+  testWidgets('Todos with initial value', (tester) async {
     // create controller with an initial value
     final initialTodos = List.generate(
       3,
@@ -56,7 +56,7 @@ void main() {
     expect(find.text('mock2'), findsOneWidget);
   });
 
-  testWidgets('Add a todo', (WidgetTester tester) async {
+  testWidgets('Add a todo', (tester) async {
     // Build our App and trigger a frame.
     await tester.pumpWidget(
       wrapWithMockedTodosController(
@@ -79,7 +79,7 @@ void main() {
     expect(find.text('test todo'), findsOneWidget);
   });
 
-  testWidgets('Remove a todo', (WidgetTester tester) async {
+  testWidgets('Remove a todo', (tester) async {
     // create controller with an initial value
     final initialTodos = List.generate(
       3,
@@ -111,7 +111,7 @@ void main() {
     expect(find.text('mock0'), findsNothing);
   });
 
-  testWidgets('Toggle a todo', (WidgetTester tester) async {
+  testWidgets('Toggle a todo', (tester) async {
     // create controller with an initial value
     final initialTodos = List.generate(
       2,

--- a/packages/flutter_solidart/test/flutter_solidart_test.dart
+++ b/packages/flutter_solidart/test/flutter_solidart_test.dart
@@ -686,6 +686,7 @@ void main() {
   });
 
   testWidgets('(ArgProvider) Signal.updateValue method', (tester) async {
+    // ignore: avoid_types_on_closure_parameters
     final counterProvider = Provider.withArgument((_, int n) => Signal(n));
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.4
+
+- **FIX**: Prevent `LateInitializationError` when accessing `Computed.untrackedValue` before first `value` access. `hasValue` now triggers lazy computation, and `untrackedValue` asserts with a clear message if accessed before computation.
+
 ## 2.8.3
 
 - **FIX**: Handle race conditions in Resource that caused multiple calls to `resolve`.

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -156,6 +156,10 @@ class Computed<T> extends ReadSignal<T> {
   @override
   T get value {
     if (_disposed) {
+      assert(
+        _initialized,
+        'Computed "$name" was disposed before its value was ever computed.',
+      );
       return _untrackedValue;
     }
 

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -125,7 +125,7 @@ class Computed<T> extends ReadSignal<T> {
 
   // A computed always reports hasValue == true, but the underlying value is
   // lazy: the selector runs on first access. Calling hasValue triggers that
-  // first computation so that untrackedValue is safe to read afterwards.
+  // first computation.
   @override
   bool get hasValue {
     if (!_disposed && !_initialized) value;

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -187,7 +187,7 @@ class Computed<T> extends ReadSignal<T> {
   T get untrackedValue {
     assert(
       _initialized,
-      'Computed "$name" has not been initialized yet. '
+      'Computed($name) has not been initialized yet. '
       'Access "value" or "hasValue" first to trigger computation.',
     );
     return _untrackedValue;

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -84,6 +84,7 @@ class Computed<T> extends ReadSignal<T> {
 
         try {
           _untrackedValue = selector();
+          _initialized = true;
 
           if (runnedOnce) {
             _notifySignalUpdate();
@@ -107,6 +108,8 @@ class Computed<T> extends ReadSignal<T> {
 
   bool _disposed = false;
 
+  bool _initialized = false;
+
   late T _untrackedValue;
 
   T? _previousValue;
@@ -120,9 +123,13 @@ class Computed<T> extends ReadSignal<T> {
   // Used later to fire each callback when this signal is disposed.
   final _onDisposeCallbacks = <VoidCallback>[];
 
-  // A computed signal is always initialized
+  // A computed signal is always initialized, but the value is lazy.
+  // Accessing hasValue triggers computation if not yet initialized.
   @override
-  bool get hasValue => true;
+  bool get hasValue {
+    if (!_disposed && !_initialized) value;
+    return true;
+  }
 
   final _deps = <alien.ReactiveNode>{};
 
@@ -177,6 +184,11 @@ class Computed<T> extends ReadSignal<T> {
   /// Returns the untracked value of the computed.
   @override
   T get untrackedValue {
+    assert(
+      _initialized,
+      'Computed "$name" has not been initialized yet. '
+      'Access "value" or "hasValue" first to trigger computation.',
+    );
     return _untrackedValue;
   }
 

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -123,8 +123,9 @@ class Computed<T> extends ReadSignal<T> {
   // Used later to fire each callback when this signal is disposed.
   final _onDisposeCallbacks = <VoidCallback>[];
 
-  // A computed signal is always initialized, but the value is lazy.
-  // Accessing hasValue triggers computation if not yet initialized.
+  // A computed always reports hasValue == true, but the underlying value is
+  // lazy: the selector runs on first access. Calling hasValue triggers that
+  // first computation so that untrackedValue is safe to read afterwards.
   @override
   bool get hasValue {
     if (!_disposed && !_initialized) value;

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -156,11 +156,7 @@ class Computed<T> extends ReadSignal<T> {
   @override
   T get value {
     if (_disposed) {
-      assert(
-        _initialized,
-        'Computed "$name" was disposed before its value was ever computed.',
-      );
-      return _untrackedValue;
+      return untrackedValue;
     }
 
     final value = reactiveSystem.getComputedValue(_internalComputed);

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 2.8.3
+version: 2.8.4
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -552,6 +552,12 @@ void main() {
         expect(doubled.untrackedValue, 10);
       });
 
+      test('untrackedValue asserts if accessed before computation', () {
+        final counter = Signal(5);
+        final doubled = Computed(() => counter.value * 2);
+        expect(() => doubled.untrackedValue, throwsA(isA<AssertionError>()));
+      });
+
       test('Computed contains previous value', () async {
         final signal = Signal(0);
         final derived = Computed(() => signal.value * 2);

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -541,6 +541,17 @@ void main() {
         },
       );
 
+      test('hasValue triggers computation, enabling untrackedValue', () {
+        final counter = Signal(5);
+        final doubled = Computed(() => counter.value * 2);
+
+        // Before any .value access, hasValue should trigger computation
+        expect(doubled.hasValue, true);
+
+        // untrackedValue should now work without LateInitializationError
+        expect(doubled.untrackedValue, 10);
+      });
+
       test('Computed contains previous value', () async {
         final signal = Signal(0);
         final derived = Computed(() => signal.value * 2);


### PR DESCRIPTION
closes #170 

Accessing untrackedValue before that threw a LateInitializationError because the late field was never populated.

- hasValue now triggers computation if not yet initialized
- untrackedValue adds an assert with a helpful message
- Add _initialized flag to track whether the selector has run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `LateInitializationError` when accessing computed values prematurely. Lazy computation now properly triggers on property access, and attempting incorrect access patterns now returns clearer error messages.

* **Tests**
  * Added tests validating lazy initialization behavior for computed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->