### PR TITLE
Computed.untrackedValue is not up to date

### DIFF
--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.3
+
+### Changes from solidart
+
+- **FIX**: Return up-to-date value from `Computed.untrackedValue` after dependency changes.
+
 ## 2.7.2
 
 ### Changes from solidart

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 2.7.2
+version: 2.7.3
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.11.0
-  solidart: ^2.8.4
+  solidart: ^2.8.5
 
 dev_dependencies:
   disco: ^1.0.0

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.5
+
+- **FIX**: Return up-to-date value from `Computed.untrackedValue` after dependency changes.
+
 ## 2.8.4
 
 - **FIX**: Prevent `LateInitializationError` when accessing `Computed.untrackedValue` before first `value` access. `hasValue` now triggers lazy computation, and `untrackedValue` asserts with a clear message if accessed before computation.

--- a/packages/solidart/lib/src/core/computed.dart
+++ b/packages/solidart/lib/src/core/computed.dart
@@ -190,6 +190,10 @@ class Computed<T> extends ReadSignal<T> {
       'Computed($name) has not been initialized yet. '
       'Access "value" or "hasValue" first to trigger computation.',
     );
+    // Re-evaluate if stale, without registering as a dependency.
+    if (!_disposed) {
+      untracked(() => value);
+    }
     return _untrackedValue;
   }
 

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 2.8.4
+version: 2.8.5
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -552,6 +552,18 @@ void main() {
         expect(doubled.untrackedValue, 10);
       });
 
+      test('untrackedValue returns up-to-date value after dependency changes',
+          () {
+        final counter = Signal(5);
+        final doubled = Computed(() => counter.value * 2);
+
+        doubled.hasValue;
+        expect(doubled.untrackedValue, 10);
+
+        counter.value = 20;
+        expect(doubled.untrackedValue, 40);
+      });
+
       test('untrackedValue asserts if accessed before computation', () {
         final counter = Signal(5);
         final doubled = Computed(() => counter.value * 2);

--- a/packages/solidart/test/solidart_test.dart
+++ b/packages/solidart/test/solidart_test.dart
@@ -570,6 +570,23 @@ void main() {
         expect(() => doubled.untrackedValue, throwsA(isA<AssertionError>()));
       });
 
+      test('untrackedValue does not register as a dependency', () {
+        final counter = Signal(5);
+        final doubled = Computed(() => counter.value * 2);
+        doubled.hasValue;
+
+        final cb = MockCallbackFunction();
+        final unobserve = Effect(() {
+          doubled.untrackedValue;
+          cb();
+        });
+        addTearDown(unobserve);
+
+        counter.value = 20;
+
+        verify(cb()).called(1); // only the initial Effect run, no re-fire
+      });
+
       test('Computed contains previous value', () async {
         final signal = Signal(0);
         final derived = Computed(() => signal.value * 2);

--- a/packages/solidart_hooks/CHANGELOG.md
+++ b/packages/solidart_hooks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.3
+
+### Changes from solidart
+
+- **FIX**: Return up-to-date value from `Computed.untrackedValue` after dependency changes.
+
 ## 3.1.2
 
 ### Changes from solidart

--- a/packages/solidart_hooks/pubspec.yaml
+++ b/packages/solidart_hooks/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart_hooks
 description: Flutter Hooks bindings for Solidart, suitable for ephemeral state and for writing less boilerplate.
-version: 3.1.2
+version: 3.1.3
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: ^0.21.3+1
-  flutter_solidart: ^2.7.2
+  flutter_solidart: ^2.7.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
closes #170 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Computed.untrackedValue` now returns the correct, up-to-date value after dependency changes, ensuring computed values remain synchronized without registering dependencies. Versions bumped: solidart to 2.8.5, flutter_solidart to 2.7.3, and solidart_hooks to 3.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->