### PR TITLE
fix: effect re-entrancy

### DIFF
--- a/packages/flutter_solidart/CHANGELOG.md
+++ b/packages/flutter_solidart/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.4
+
+### Changes from solidart
+
+- **FIX**: Prevent effect re-entrancy when a signal is written during the effect's first run. The write no longer re-enters the running effect mid-execution, which could throw `LateInitializationError`.
+
 ## 2.7.3
 
 ### Changes from solidart

--- a/packages/flutter_solidart/pubspec.yaml
+++ b/packages/flutter_solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_solidart
 description: A simple State Management solution for Flutter applications inspired by SolidJS
-version: 2.7.3
+version: 2.7.4
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.11.0
-  solidart: ^2.8.5
+  solidart: ^2.8.6
 
 dev_dependencies:
   disco: ^1.0.0

--- a/packages/solidart/CHANGELOG.md
+++ b/packages/solidart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.6
+
+- **FIX**: Prevent effect re-entrancy when a signal is written during the effect's first run. The write no longer re-enters the running effect mid-execution, which could throw `LateInitializationError`.
+
 ## 2.8.5
 
 - **FIX**: Return up-to-date value from `Computed.untrackedValue` after dependency changes.

--- a/packages/solidart/lib/src/core/effect.dart
+++ b/packages/solidart/lib/src/core/effect.dart
@@ -195,6 +195,7 @@ class Effect implements ReactionInterface {
       }
     } finally {
       reactiveSystem.endBatch();
+      // ignore: cascade_invocations
       reactiveSystem.setCurrentSub(prevSub);
       if (SolidartConfig.autoDispose) {
         _mayDispose();

--- a/packages/solidart/lib/src/core/effect.dart
+++ b/packages/solidart/lib/src/core/effect.dart
@@ -184,6 +184,7 @@ class Effect implements ReactionInterface {
     }
     final prevSub = reactiveSystem.setCurrentSub(_internalEffect);
 
+    reactiveSystem.startBatch();
     try {
       _internalEffect.run();
     } catch (e, s) {
@@ -193,6 +194,7 @@ class Effect implements ReactionInterface {
         rethrow;
       }
     } finally {
+      reactiveSystem.endBatch();
       reactiveSystem.setCurrentSub(prevSub);
       if (SolidartConfig.autoDispose) {
         _mayDispose();

--- a/packages/solidart/pubspec.yaml
+++ b/packages/solidart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart
 description: A simple State Management solution for Dart applications inspired by SolidJS
-version: 2.8.5
+version: 2.8.6
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:

--- a/packages/solidart/test/reentrancy_test.dart
+++ b/packages/solidart/test/reentrancy_test.dart
@@ -1,0 +1,73 @@
+import 'package:solidart/solidart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('effect re-entrancy during initial run', () {
+    test(
+      '''a signal write during the effect first run does not re-enter the effect callback while it is still on the stack''',
+      () {
+        SolidartConfig.autoDispose = false;
+        final source = Signal(0, name: 'source');
+        var running = false;
+        var maxConcurrentDepth = 0;
+        var runs = 0;
+
+        final effect = Effect(() {
+          runs++;
+          // Detect re-entrancy: if the callback is invoked while a previous
+          // invocation is still on the stack, `running` is already true.
+          expect(running, isFalse, reason: 'effect re-entered its own run');
+          running = true;
+          maxConcurrentDepth++;
+
+          // Subscribe to `source`, then write it during the FIRST run. With
+          // synchronous flush this re-enters the callback before `running`
+          // is reset → the expect above fails.
+          final value = source.value;
+          if (runs == 1) {
+            source.value = value + 1;
+          }
+
+          maxConcurrentDepth--;
+          running = false;
+        });
+
+        addTearDown(effect.dispose);
+        expect(maxConcurrentDepth, 0);
+        // The effect re-runs once (sequentially) for the value change.
+        expect(runs, 2);
+        expect(source.value, 1);
+      },
+    );
+
+    test(
+      '''a late-final read inside the effect survives a write triggered mid-construction''',
+      () {
+        SolidartConfig.autoDispose = false;
+        // `dep` mimics a controller built lazily during the effect run whose
+        // constructor writes to a collection signal.
+        final trigger = Signal(0, name: 'trigger');
+        late final int lazy;
+        var lazyInitialized = false;
+
+        final effect = Effect(() {
+          // Read `trigger` (subscribe). On first run, lazily initialize a
+          // value whose initializer writes `trigger` — a synchronous flush
+          // would re-enter HERE before `lazy` finishes initializing.
+          final t = trigger.value;
+          if (!lazyInitialized) {
+            lazyInitialized = true;
+            // Initializer body writes the signal the effect depends on.
+            trigger.value = t + 1;
+            lazy = 42;
+          }
+          // Reading `lazy` must never throw LateInitializationError.
+          expect(lazy, 42);
+        });
+
+        addTearDown(effect.dispose);
+        expect(lazy, 42);
+      },
+    );
+  });
+}

--- a/packages/solidart/test/reentrancy_test.dart
+++ b/packages/solidart/test/reentrancy_test.dart
@@ -6,6 +6,8 @@ void main() {
     test(
       '''a signal write during the effect first run does not re-enter the effect callback while it is still on the stack''',
       () {
+        final previousAutoDispose = SolidartConfig.autoDispose;
+        addTearDown(() => SolidartConfig.autoDispose = previousAutoDispose);
         SolidartConfig.autoDispose = false;
         final source = Signal(0, name: 'source');
         var running = false;
@@ -43,6 +45,8 @@ void main() {
     test(
       '''a late-final read inside the effect survives a write triggered mid-construction''',
       () {
+        final previousAutoDispose = SolidartConfig.autoDispose;
+        addTearDown(() => SolidartConfig.autoDispose = previousAutoDispose);
         SolidartConfig.autoDispose = false;
         // `dep` mimics a controller built lazily during the effect run whose
         // constructor writes to a collection signal.

--- a/packages/solidart_hooks/CHANGELOG.md
+++ b/packages/solidart_hooks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.4
+
+### Changes from solidart
+
+- **FIX**: Prevent effect re-entrancy when a signal is written during the effect's first run. The write no longer re-enters the running effect mid-execution, which could throw `LateInitializationError`.
+
 ## 3.1.3
 
 ### Changes from solidart

--- a/packages/solidart_hooks/pubspec.yaml
+++ b/packages/solidart_hooks/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidart_hooks
 description: Flutter Hooks bindings for Solidart, suitable for ephemeral state and for writing less boilerplate.
-version: 3.1.3
+version: 3.1.4
 repository: https://github.com/nank1ro/solidart
 documentation: https://solidart.mariuti.com
 topics:
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: ^0.21.3+1
-  flutter_solidart: ^2.7.3
+  flutter_solidart: ^2.7.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed effect re-entrancy that could cause initialization errors when a signal is updated during an effect’s initial run.

* **Tests**
  * Added tests covering effect re-entrancy and safe lazy initialization during effect setup.

* **Chores**
  * Package version bumps: solidart → 2.8.6, flutter_solidart → 2.7.4, solidart_hooks → 3.1.4.

* **Documentation**
  * Changelog entries added documenting the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nank1ro/solidart/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->